### PR TITLE
fix verify-beta-testnet

### DIFF
--- a/op-program/verify/beta-testnet/cmd/beta-testnet.go
+++ b/op-program/verify/beta-testnet/cmd/beta-testnet.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/ethereum-optimism/optimism/op-program/verify"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -44,7 +45,7 @@ func main() {
 	}
 
 	// Apply the custom configs by running op-program
-	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "3335", 3335, false)
+	runner, err := verify.NewRunner(l1RpcUrl, l1RpcKind, l1BeaconUrl, l2RpcUrl, dataDir, "3335", eth.ChainIDFromUInt64(3335), false)
 	if err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Failed to create runner: %v\n", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
The `chainID` param has been refactored to `eth.ChainID`.