### PR TITLE
CircleCI: update config.yml for upstream merge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1262,7 +1262,7 @@ jobs:
       - image: returntocorp/semgrep
     resource_class: xlarge
     steps:
-      - checkout-with-mise # no need to use mise here since the docker image contains the only dependency
+      - checkout # no need to use mise here since the docker image contains the only dependency
       - unless:
           condition:
             equal: [ "op-es", << pipeline.git.branch >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,9 +367,8 @@ jobs:
           mentions: "@clabby @proofs-team"
 
   contracts-bedrock-build:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: large
+    machine: true
+    resource_class: qkc/ax101
     parameters:
       build_args:
         description: Forge build arguments
@@ -982,9 +981,8 @@ jobs:
         description: should load in foundry artifacts
         type: boolean
         default: false
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: xlarge
+    machine: true
+    resource_class: qkc/ax101
     steps:
       - checkout-with-mise
       - check-changed:
@@ -1115,9 +1113,8 @@ jobs:
                 mentions: "<<parameters.mentions>>"
 
   sanitize-op-program:
-    docker:
-      - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: large
+    machine: true
+    resource_class: qkc/ax101
     steps:
       - checkout-with-mise
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
     parameters:
       mise_data_dir:
         type: string
-        default: "$HOME/.mise-data"
+        default: "~/.mise-data"
     steps:
       - checkout
       - run:
@@ -70,6 +70,7 @@ commands:
             user=$(whoami)
             echo "$user" > .executor-user
             echo "Set executor user to $user."
+            echo "Mise data dir: << parameters.mise_data_dir >>."
             if [[ "$user" == "root" ]]; then
               rm -rf << parameters.mise_data_dir >>
               echo "Cleaned up cache data."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ commands:
 jobs:
   cannon-go-lint-and-test:
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     parameters:
       skip_slow_tests:
         type: boolean
@@ -308,7 +308,7 @@ jobs:
 
   contracts-bedrock-build:
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     parameters:
       build_args:
         description: Forge build arguments
@@ -605,7 +605,7 @@ jobs:
 
   contracts-bedrock-frozen-code:
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - attach_workspace: { at: "." }
@@ -855,7 +855,7 @@ jobs:
 
   contracts-bedrock-checks:
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - attach_workspace: { at: "." }
@@ -920,7 +920,7 @@ jobs:
         type: boolean
         default: false
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - check-changed:
@@ -945,7 +945,7 @@ jobs:
 
   go-lint:
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - run:
@@ -967,7 +967,7 @@ jobs:
       resource_class:
         description: Machine resource class
         type: string
-        default: swc/ax101
+        default: qkc/ax101
       no_output_timeout:
         description: Timeout for when CircleCI kills the job if there's no output
         type: string
@@ -984,7 +984,7 @@ jobs:
         description: List of packages to test
         type: string
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - attach_workspace:
@@ -1052,7 +1052,7 @@ jobs:
 
   sanitize-op-program:
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - run:
@@ -1236,7 +1236,7 @@ jobs:
   fpp-verify:
     circleci_ip_ranges: true
     machine: true
-    resource_class: swc/ax101
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - run:
@@ -1722,7 +1722,7 @@ workflows:
           mentions: "@proofs-team"
           no_output_timeout: 60m
           test_timeout: 59m
-          resource_class: swc/ax101
+          resource_class: qkc/ax101
           environment_overrides: |
             export OP_E2E_CANNON_ENABLED="true"
             export PARALLEL=24

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1491,7 +1491,7 @@ workflows:
       - contracts-bedrock-frozen-code:
           requires:
             - contracts-bedrock-build
-      - diff-asterisc-bytecode
+      # - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,65 @@ orbs:
   codecov: codecov/codecov@5.0.3
 
 commands:
+  checkout-with-mise:
+    description: "Checkout then initialize the mise environment"
+    steps:
+      - checkout
+      - run:
+          name: "Initialize mise environment"
+          command: |
+            # This is used to create a per-user cache key to preserve permissions across different
+            # executor types.
+            user=$(whoami)
+            echo "$user" > .executor-user
+            echo "Set executor user to $user."
+            if [[ "$user" == "root" ]]; then
+              rm -rf /data/mise-data
+              echo "Cleaned up cache data."
+              mkdir -p /data/mise-data
+              echo "Created Mise data dir."
+              mkdir -p ~/.cache
+              echo "Created Mise cache dir."
+            else
+              sudo rm -rf /data/mise-data
+              echo "Cleaned up cache data."
+              sudo mkdir -p /data/mise-data
+              sudo chown -R "$user:$user" /data/mise-data
+              echo "Created Mise data dir."
+              sudo mkdir -p ~/.cache
+              sudo chown -R "$user:$user" ~/.cache
+              echo "Created Mise cache dir."
+            fi
+      - restore_cache:
+          name: Restore mise cache
+          keys:
+            - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+      - run:
+          name: Install mise
+          command: |
+            if command -v mise &> /dev/null; then
+              echo "mise already installed at $(command -v mise)"
+            else
+              curl https://mise.run | sh
+            fi
+            echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
+            echo "export MISE_DATA_DIR=/data/mise-data" >> "$BASH_ENV"
+            echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"
+            echo "eval \"\$($HOME/.local/bin/mise activate --shims)\"" >> "$BASH_ENV"
+      - run:
+          name: Install mise deps
+          command: |
+            mise install -v -y
+      - save_cache:
+          name: Save mise cache
+          key: mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+          paths:
+            - /data/mise-data
+      - run:
+          name: Delete executor file
+          command: |
+            rm -f .executor-user
+
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."
     parameters:
@@ -163,74 +222,6 @@ commands:
             FOUNDRY_PROFILE: ci
 
 jobs:
-  initialize:
-    machine: true
-    resource_class: qkc/ax101
-    environment:
-      MISE_CACHE_DIR: ~/circleci/.cache
-      MISE_DATA_DIR: ~/circleci/data/mise-data
-    steps:
-      - run:
-          name: Initialize mise environment
-          command: |
-            # This is used to create a per-user cache key to preserve permissions across different
-            # executor types.
-            user=$(whoami)
-            echo "$user" > .executor-user
-            echo "Set executor user to $user."
-
-            if [[ "$user" == "root" ]]; then
-              # Self-hosted runners will persist this cache between runs. Cleaning it up means that we
-              # preserve the semantics of the cache regardless of executor type. It's also much faster
-              # to delete the cache and recreate it than it is to overwrite it in place.
-              rm -rf "$MISE_DATA_DIR"
-              echo "Cleaned up cache data."
-
-              mkdir -p "$MISE_DATA_DIR"
-              echo "Created Mise data dir."
-              mkdir -p "$MISE_CACHE_DIR"
-              echo "Created Mise cache dir."
-            else
-              sudo rm -rf "$MISE_DATA_DIR"
-              echo "Cleaned up cache data."
-              sudo mkdir -p "$MISE_DATA_DIR"
-              sudo chown -R "$user:$user" "$MISE_DATA_DIR"
-              echo "Created Mise data dir."
-              sudo mkdir -p "$MISE_CACHE_DIR"
-              sudo chown -R "$user:$user" "$MISE_CACHE_DIR"
-              echo "Created Mise cache dir."
-            fi
-      - restore_cache:
-          name: Restore mise cache
-          keys:
-            - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
-      - run:
-          name: Install mise
-          command: |
-            if command -v mise &> /dev/null; then
-              echo "mise already installed at $(command -v mise)"
-            else
-              curl https://mise.run | sh
-            fi
-
-            echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
-            echo "export MISE_DATA_DIR=$MISE_DATA_DIR" >> "$BASH_ENV"
-            echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"
-            echo "eval \"\$($HOME/.local/bin/mise activate --shims)\"" >> "$BASH_ENV"
-      - run:
-          name: Install mise deps
-          command: |
-            mise install -v -y
-      - save_cache:
-          name: Save mise cache
-          key: mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
-          paths:
-            - "$MISE_DATA_DIR"
-      - run:
-          name: Delete executor file
-          command: |
-            rm -f .executor-user
-
   cannon-go-lint-and-test:
     machine: true
     resource_class: qkc/ax101
@@ -246,7 +237,7 @@ jobs:
         type: integer
         default: 32
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
       - attach_workspace:
@@ -319,7 +310,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: cannon/mipsevm/tests/open_mips_tests/test
       - run:
@@ -338,7 +329,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Check `RISCV.sol` bytecode
           working_directory: packages/contracts-bedrock
@@ -374,8 +365,9 @@ jobs:
           mentions: "@clabby @proofs-team"
 
   contracts-bedrock-build:
-    machine: true
-    resource_class: qkc/ax101
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: large
     parameters:
       build_args:
         description: Forge build arguments
@@ -386,7 +378,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout
+      - checkout-with-mise
       - install-contracts-dependencies
       - run:
           name: Print forge version
@@ -416,7 +408,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -477,7 +469,7 @@ jobs:
       resource_class: "<<parameters.resource_class>>"
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           command: git submodule update --init
       - attach_workspace:
@@ -676,7 +668,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -726,7 +718,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - run:
@@ -804,7 +796,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -863,7 +855,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -926,7 +918,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -967,7 +959,7 @@ jobs:
     machine:
       image: <<pipeline.parameters.base_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Install ripgrep
           command: sudo apt-get install -y ripgrep
@@ -988,10 +980,11 @@ jobs:
         description: should load in foundry artifacts
         type: boolean
         default: false
-    machine: true
-    resource_class: qkc/ax101
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: xlarge
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: "<<parameters.package_name>>"
       - attach_workspace:
@@ -1016,7 +1009,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: run Go linter
           command: |
@@ -1053,9 +1046,9 @@ jobs:
         description: List of packages to test
         type: string
     machine: true
-    resource_class: qkc/ax101
+    resource_class: <<parameters.resource_class>>
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace:
           at: "."
       - run:
@@ -1120,10 +1113,11 @@ jobs:
                 mentions: "<<parameters.mentions>>"
 
   sanitize-op-program:
-    machine: true
-    resource_class: qkc/ax101
+    docker:
+      - image: <<pipeline.parameters.default_docker_image>>
+    resource_class: large
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: Install tools
           command: |
@@ -1145,7 +1139,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - restore_cache:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
@@ -1170,7 +1164,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - setup_remote_docker
       - run:
           name: Build prestates
@@ -1185,7 +1179,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - attach_workspace:
           at: "."
       - gcp-cli/install
@@ -1230,7 +1224,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - setup_remote_docker
       - run: make -C op-program verify-reproducibility
       - notify-failures-on-develop:
@@ -1240,7 +1234,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - checkout
+      - checkout-with-mise
       - setup_remote_docker
       - run:
           name: Build cannon
@@ -1268,7 +1262,7 @@ jobs:
       - image: returntocorp/semgrep
     resource_class: xlarge
     steps:
-      - checkout # no need to use mise here since the docker image contains the only dependency
+      - checkout-with-mise # no need to use mise here since the docker image contains the only dependency
       - unless:
           condition:
             equal: [ "op-es", << pipeline.git.branch >> ]
@@ -1307,7 +1301,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: verify-sepolia
           command: |
@@ -1320,7 +1314,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - run:
           name: compat-sepolia
           command: |
@@ -1331,7 +1325,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: op-node
       - run:
@@ -1342,7 +1336,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - checkout
+      - checkout-with-mise
       - check-changed:
           patterns: op-service
       - run:
@@ -1354,7 +1348,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - checkout
+      - checkout-with-mise
       - install-contracts-dependencies
       - check-changed:
           no_go_deps: "true"
@@ -1391,7 +1385,7 @@ jobs:
           oidc_token_file_path: /tmp/oidc_token.json
           project_id: GCP_TOOLS_ARTIFACTS_PROJECT_ID
           service_account_email: GCP_CONTRACTS_PUBLISHER_SERVICE_ACCOUNT_EMAIL
-      - checkout
+      - checkout-with-mise
       - install-contracts-dependencies
       - run:
           name: Pull artifacts
@@ -1426,7 +1420,7 @@ jobs:
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /tmp/gcp_cred_config.json
           oidc_token_file_path: /tmp/oidc_token.json
-      - checkout
+      - checkout-with-mise
       - run:
           name: Configure Docker
           command: |
@@ -1460,12 +1454,8 @@ workflows:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
-      - initialize:
-          name: initialize-mise-environment
       - contracts-bedrock-build:
           name: contracts-bedrock-build
-          requires:
-            - initialize-mise-environment
           # Build with just core + script contracts.
           build_args: --deny-warnings --skip test
       - check-kontrol-build:
@@ -1501,9 +1491,7 @@ workflows:
       - contracts-bedrock-frozen-code:
           requires:
             - contracts-bedrock-build
-      - diff-asterisc-bytecode:
-          requires:
-            - initialize-mise-environment
+      - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
@@ -1514,8 +1502,6 @@ workflows:
       - fuzz-golang:
           name: fuzz-golang-<<matrix.package_name>>
           on_changes: <<matrix.package_name>>
-          requires:
-            - initialize-mise-environment
           matrix:
             parameters:
               package_name:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1488,9 +1488,9 @@ workflows:
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build
-      - contracts-bedrock-frozen-code:
-          requires:
-            - contracts-bedrock-build
+      # - contracts-bedrock-frozen-code:
+      #     requires:
+      #       - contracts-bedrock-build
       - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
       - restore_cache:
           name: "Restore mise cache"
           keys:
-            - "mise-v5-<< parameters.mise_data_dir >>-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+            - "mise-v5-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
       - run:
           name: "Install mise"
           command: |
@@ -110,7 +110,7 @@ commands:
             mise install -v -y
       - save_cache:
           name: "Save mise cache"
-          key: "mise-v5-<< parameters.mise_data_dir >>-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+          key: "mise-v5-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
           paths:
             - << parameters.mise_data_dir >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1488,9 +1488,9 @@ workflows:
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build
-      # - contracts-bedrock-frozen-code:
-      #     requires:
-      #       - contracts-bedrock-build
+      - contracts-bedrock-frozen-code:
+          requires:
+            - contracts-bedrock-build
       - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,6 +411,8 @@ jobs:
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
       - utils/checkout-with-mise
+      - run:
+          command: git submodule update --init
       - attach_workspace:
           at: /tmp/docker_images
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
     parameters:
       mise_data_dir:
         type: string
-        default: "~/.mise-data"
+        default: "$HOME/.mise-data"
     steps:
       - checkout
       - run:
@@ -1498,28 +1498,28 @@ workflows:
           name: semgrep-test
           scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/
       - go-lint
-      - fuzz-golang:
-          name: fuzz-golang-<<matrix.package_name>>
-          on_changes: <<matrix.package_name>>
-          matrix:
-            parameters:
-              package_name:
-                - op-challenger
-                - op-node
-                - op-service
-                - op-chain-ops
-      - fuzz-golang:
-          name: cannon-fuzz
-          package_name: cannon
-          on_changes: cannon,packages/contracts-bedrock/src/cannon
-          uses_artifacts: true
-          requires: ["contracts-bedrock-build"]
-      - fuzz-golang:
-          name: op-e2e-fuzz
-          package_name: op-e2e
-          on_changes: op-e2e,packages/contracts-bedrock/src
-          uses_artifacts: true
-          requires: ["contracts-bedrock-build"]
+      # - fuzz-golang:
+      #     name: fuzz-golang-<<matrix.package_name>>
+      #     on_changes: <<matrix.package_name>>
+      #     matrix:
+      #       parameters:
+      #         package_name:
+      #           - op-challenger
+      #           - op-node
+      #           - op-service
+      #           - op-chain-ops
+      # - fuzz-golang:
+      #     name: cannon-fuzz
+      #     package_name: cannon
+      #     on_changes: cannon,packages/contracts-bedrock/src/cannon
+      #     uses_artifacts: true
+      #     requires: ["contracts-bedrock-build"]
+      # - fuzz-golang:
+      #     name: op-e2e-fuzz
+      #     package_name: op-e2e
+      #     on_changes: op-e2e,packages/contracts-bedrock/src
+      #     uses_artifacts: true
+      #     requires: ["contracts-bedrock-build"]
       - go-tests:
           environment_overrides: |
             export PARALLEL=24
@@ -1548,42 +1548,42 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate-quick
       - op-program-compat
-      - bedrock-go-tests:
-          requires:
-            - go-lint
-            - cannon-build-test-vectors
-            - cannon-go-lint-and-test-32-bit
-            - cannon-go-lint-and-test-64-bit
-            - check-generated-mocks-op-node
-            - check-generated-mocks-op-service
-            - op-program-compat
-            # Not needed for the devnet but we want to make sure they build successfully
-            - cannon-docker-build
-            - op-dispute-mon-docker-build
-            - op-program-docker-build
-            - op-supervisor-docker-build
-            - proofs-tools-docker-build
-            - go-tests
-            - sanitize-op-program
-      - docker-build:
-          name: <<matrix.docker_name>>-docker-build
-          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-          save_image_tag: <<pipeline.git.revision>>
-          matrix:
-            parameters:
-              docker_name:
-                - op-node
-                - op-batcher
-                - op-program
-                - op-proposer
-                - op-challenger
-                - proofs-tools
-                - op-dispute-mon
-                - op-conductor
-                - da-server
-                - op-supervisor
-                - cannon
-                - op-dripper
+      # - bedrock-go-tests:
+      #     requires:
+      #       - go-lint
+      #       - cannon-build-test-vectors
+      #       - cannon-go-lint-and-test-32-bit
+      #       - cannon-go-lint-and-test-64-bit
+      #       - check-generated-mocks-op-node
+      #       - check-generated-mocks-op-service
+      #       - op-program-compat
+      #       # Not needed for the devnet but we want to make sure they build successfully
+      #       - cannon-docker-build
+      #       - op-dispute-mon-docker-build
+      #       - op-program-docker-build
+      #       - op-supervisor-docker-build
+      #       - proofs-tools-docker-build
+      #       - go-tests
+      #       - sanitize-op-program
+      # - docker-build:
+      #     name: <<matrix.docker_name>>-docker-build
+      #     docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+      #     save_image_tag: <<pipeline.git.revision>>
+      #     matrix:
+      #       parameters:
+      #         docker_name:
+      #           - op-node
+      #           - op-batcher
+      #           - op-program
+      #           - op-proposer
+      #           - op-challenger
+      #           - proofs-tools
+      #           - op-dispute-mon
+      #           - op-conductor
+      #           - da-server
+      #           - op-supervisor
+      #           - cannon
+      #           - op-dripper
       - cannon-prestate-quick
       - sanitize-op-program:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,39 +58,41 @@ orbs:
 commands:
   checkout-with-mise:
     description: "Checkout then initialize the mise environment"
+    parameters:
+      mise_data_dir:
+        type: string
+        default: "~/.mise-data"
     steps:
       - checkout
       - run:
           name: "Initialize mise environment"
           command: |
-            # This is used to create a per-user cache key to preserve permissions across different
-            # executor types.
             user=$(whoami)
             echo "$user" > .executor-user
             echo "Set executor user to $user."
             if [[ "$user" == "root" ]]; then
-              rm -rf /data/mise-data
+              rm -rf << parameters.mise_data_dir >>
               echo "Cleaned up cache data."
-              mkdir -p /data/mise-data
+              mkdir -p << parameters.mise_data_dir >>
               echo "Created Mise data dir."
               mkdir -p ~/.cache
               echo "Created Mise cache dir."
             else
-              sudo rm -rf /data/mise-data
+              rm -rf << parameters.mise_data_dir >>
               echo "Cleaned up cache data."
-              sudo mkdir -p /data/mise-data
-              sudo chown -R "$user:$user" /data/mise-data
+              mkdir -p << parameters.mise_data_dir >>
+              chown -R "$user:$user" << parameters.mise_data_dir >>
               echo "Created Mise data dir."
-              sudo mkdir -p ~/.cache
-              sudo chown -R "$user:$user" ~/.cache
+              mkdir -p ~/.cache
+              chown -R "$user:$user" ~/.cache
               echo "Created Mise cache dir."
             fi
       - restore_cache:
-          name: Restore mise cache
+          name: "Restore mise cache"
           keys:
-            - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+            - "mise-v5-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
       - run:
-          name: Install mise
+          name: "Install mise"
           command: |
             if command -v mise &> /dev/null; then
               echo "mise already installed at $(command -v mise)"
@@ -98,20 +100,20 @@ commands:
               curl https://mise.run | sh
             fi
             echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
-            echo "export MISE_DATA_DIR=/data/mise-data" >> "$BASH_ENV"
+            echo "export MISE_DATA_DIR=<< parameters.mise_data_dir >>" >> "$BASH_ENV"
             echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"
             echo "eval \"\$($HOME/.local/bin/mise activate --shims)\"" >> "$BASH_ENV"
       - run:
-          name: Install mise deps
+          name: "Install mise deps"
           command: |
             mise install -v -y
       - save_cache:
-          name: Save mise cache
-          key: mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+          name: "Save mise cache"
+          key: "mise-v5-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
           paths:
-            - /data/mise-data
+            - << parameters.mise_data_dir >>
       - run:
-          name: Delete executor file
+          name: "Delete executor file"
           command: |
             rm -f .executor-user
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
       - restore_cache:
           name: "Restore mise cache"
           keys:
-            - "mise-v5-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+            - "mise-v5-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
       - run:
           name: "Install mise"
           command: |
@@ -110,7 +110,7 @@ commands:
             mise install -v -y
       - save_cache:
           name: "Save mise cache"
-          key: "mise-v5-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+          key: "mise-v5-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
           paths:
             - << parameters.mise_data_dir >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1461,9 +1461,11 @@ workflows:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
       - initialize:
-          name: checkout-and-init-mise
+          name: initialize-mise-environment
       - contracts-bedrock-build:
           name: contracts-bedrock-build
+          requires:
+            - initialize-mise-environment
           # Build with just core + script contracts.
           build_args: --deny-warnings --skip test
       - check-kontrol-build:
@@ -1499,7 +1501,9 @@ workflows:
       - contracts-bedrock-frozen-code:
           requires:
             - contracts-bedrock-build
-      - diff-asterisc-bytecode
+      - diff-asterisc-bytecode:
+          requires:
+            - initialize-mise-environment
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
@@ -1510,6 +1514,8 @@ workflows:
       - fuzz-golang:
           name: fuzz-golang-<<matrix.package_name>>
           on_changes: <<matrix.package_name>>
+          requires:
+            - initialize-mise-environment
           matrix:
             parameters:
               package_name:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands:
       - restore_cache:
           name: "Restore mise cache"
           keys:
-            - "mise-v5-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+            - "mise-v5-<< parameters.mise_data_dir >>-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
       - run:
           name: "Install mise"
           command: |
@@ -109,7 +109,7 @@ commands:
             mise install -v -y
       - save_cache:
           name: "Save mise cache"
-          key: "mise-v5-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+          key: "mise-v5-<< parameters.mise_data_dir >>-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
           paths:
             - << parameters.mise_data_dir >>
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1491,7 +1491,7 @@ workflows:
       - contracts-bedrock-frozen-code:
           requires:
             - contracts-bedrock-build
-      # - diff-asterisc-bytecode
+      - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local
           scan_command: semgrep scan --timeout=100 --config .semgrep/rules/ --error .
@@ -1499,28 +1499,28 @@ workflows:
           name: semgrep-test
           scan_command: semgrep scan --test --config .semgrep/rules/ .semgrep/tests/
       - go-lint
-      # - fuzz-golang:
-      #     name: fuzz-golang-<<matrix.package_name>>
-      #     on_changes: <<matrix.package_name>>
-      #     matrix:
-      #       parameters:
-      #         package_name:
-      #           - op-challenger
-      #           - op-node
-      #           - op-service
-      #           - op-chain-ops
-      # - fuzz-golang:
-      #     name: cannon-fuzz
-      #     package_name: cannon
-      #     on_changes: cannon,packages/contracts-bedrock/src/cannon
-      #     uses_artifacts: true
-      #     requires: ["contracts-bedrock-build"]
-      # - fuzz-golang:
-      #     name: op-e2e-fuzz
-      #     package_name: op-e2e
-      #     on_changes: op-e2e,packages/contracts-bedrock/src
-      #     uses_artifacts: true
-      #     requires: ["contracts-bedrock-build"]
+      - fuzz-golang:
+          name: fuzz-golang-<<matrix.package_name>>
+          on_changes: <<matrix.package_name>>
+          matrix:
+            parameters:
+              package_name:
+                - op-challenger
+                - op-node
+                - op-service
+                - op-chain-ops
+      - fuzz-golang:
+          name: cannon-fuzz
+          package_name: cannon
+          on_changes: cannon,packages/contracts-bedrock/src/cannon
+          uses_artifacts: true
+          requires: ["contracts-bedrock-build"]
+      - fuzz-golang:
+          name: op-e2e-fuzz
+          package_name: op-e2e
+          on_changes: op-e2e,packages/contracts-bedrock/src
+          uses_artifacts: true
+          requires: ["contracts-bedrock-build"]
       - go-tests:
           environment_overrides: |
             export PARALLEL=24
@@ -1549,42 +1549,42 @@ workflows:
             - contracts-bedrock-build
             - cannon-prestate-quick
       - op-program-compat
-      # - bedrock-go-tests:
-      #     requires:
-      #       - go-lint
-      #       - cannon-build-test-vectors
-      #       - cannon-go-lint-and-test-32-bit
-      #       - cannon-go-lint-and-test-64-bit
-      #       - check-generated-mocks-op-node
-      #       - check-generated-mocks-op-service
-      #       - op-program-compat
-      #       # Not needed for the devnet but we want to make sure they build successfully
-      #       - cannon-docker-build
-      #       - op-dispute-mon-docker-build
-      #       - op-program-docker-build
-      #       - op-supervisor-docker-build
-      #       - proofs-tools-docker-build
-      #       - go-tests
-      #       - sanitize-op-program
-      # - docker-build:
-      #     name: <<matrix.docker_name>>-docker-build
-      #     docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
-      #     save_image_tag: <<pipeline.git.revision>>
-      #     matrix:
-      #       parameters:
-      #         docker_name:
-      #           - op-node
-      #           - op-batcher
-      #           - op-program
-      #           - op-proposer
-      #           - op-challenger
-      #           - proofs-tools
-      #           - op-dispute-mon
-      #           - op-conductor
-      #           - da-server
-      #           - op-supervisor
-      #           - cannon
-      #           - op-dripper
+      - bedrock-go-tests:
+          requires:
+            - go-lint
+            - cannon-build-test-vectors
+            - cannon-go-lint-and-test-32-bit
+            - cannon-go-lint-and-test-64-bit
+            - check-generated-mocks-op-node
+            - check-generated-mocks-op-service
+            - op-program-compat
+            # Not needed for the devnet but we want to make sure they build successfully
+            - cannon-docker-build
+            - op-dispute-mon-docker-build
+            - op-program-docker-build
+            - op-supervisor-docker-build
+            - proofs-tools-docker-build
+            - go-tests
+            - sanitize-op-program
+      - docker-build:
+          name: <<matrix.docker_name>>-docker-build
+          docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
+          save_image_tag: <<pipeline.git.revision>>
+          matrix:
+            parameters:
+              docker_name:
+                - op-node
+                - op-batcher
+                - op-program
+                - op-proposer
+                - op-challenger
+                - proofs-tools
+                - op-dispute-mon
+                - op-conductor
+                - da-server
+                - op-supervisor
+                - cannon
+                - op-dripper
       - cannon-prestate-quick
       - sanitize-op-program:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,6 @@ orbs:
   slack: circleci/slack@4.10.1
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: karlb/circleci-utils@0.1.0
 
 commands:
   gcp-oidc-authenticate:
@@ -164,6 +163,74 @@ commands:
             FOUNDRY_PROFILE: ci
 
 jobs:
+  initialize:
+    machine: true
+    resource_class: qkc/ax101
+    environment:
+      MISE_CACHE_DIR: ~/circleci/.cache
+      MISE_DATA_DIR: ~/circleci/data/mise-data
+    steps:
+      - run:
+          name: Initialize mise environment
+          command: |
+            # This is used to create a per-user cache key to preserve permissions across different
+            # executor types.
+            user=$(whoami)
+            echo "$user" > .executor-user
+            echo "Set executor user to $user."
+
+            if [[ "$user" == "root" ]]; then
+              # Self-hosted runners will persist this cache between runs. Cleaning it up means that we
+              # preserve the semantics of the cache regardless of executor type. It's also much faster
+              # to delete the cache and recreate it than it is to overwrite it in place.
+              rm -rf "$MISE_DATA_DIR"
+              echo "Cleaned up cache data."
+
+              mkdir -p "$MISE_DATA_DIR"
+              echo "Created Mise data dir."
+              mkdir -p "$MISE_CACHE_DIR"
+              echo "Created Mise cache dir."
+            else
+              sudo rm -rf "$MISE_DATA_DIR"
+              echo "Cleaned up cache data."
+              sudo mkdir -p "$MISE_DATA_DIR"
+              sudo chown -R "$user:$user" "$MISE_DATA_DIR"
+              echo "Created Mise data dir."
+              sudo mkdir -p "$MISE_CACHE_DIR"
+              sudo chown -R "$user:$user" "$MISE_CACHE_DIR"
+              echo "Created Mise cache dir."
+            fi
+      - restore_cache:
+          name: Restore mise cache
+          keys:
+            - mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+      - run:
+          name: Install mise
+          command: |
+            if command -v mise &> /dev/null; then
+              echo "mise already installed at $(command -v mise)"
+            else
+              curl https://mise.run | sh
+            fi
+
+            echo "export PATH=\"$HOME/.local/bin:\$PATH\"" >> "$BASH_ENV"
+            echo "export MISE_DATA_DIR=$MISE_DATA_DIR" >> "$BASH_ENV"
+            echo "export MISE_JOBS=$(nproc)" >> "$BASH_ENV"
+            echo "eval \"\$($HOME/.local/bin/mise activate --shims)\"" >> "$BASH_ENV"
+      - run:
+          name: Install mise deps
+          command: |
+            mise install -v -y
+      - save_cache:
+          name: Save mise cache
+          key: mise-v5-{{ checksum ".executor-user" }}-{{ checksum "mise.toml" }}
+          paths:
+            - "$MISE_DATA_DIR"
+      - run:
+          name: Delete executor file
+          command: |
+            rm -f .executor-user
+
   cannon-go-lint-and-test:
     machine: true
     resource_class: qkc/ax101
@@ -179,7 +246,7 @@ jobs:
         type: integer
         default: 32
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - check-changed:
           patterns: cannon,packages/contracts-bedrock/src/cannon,op-preimage,go.mod
       - attach_workspace:
@@ -252,7 +319,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - check-changed:
           patterns: cannon/mipsevm/tests/open_mips_tests/test
       - run:
@@ -271,7 +338,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: Check `RISCV.sol` bytecode
           working_directory: packages/contracts-bedrock
@@ -319,7 +386,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - install-contracts-dependencies
       - run:
           name: Print forge version
@@ -349,7 +416,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -410,7 +477,7 @@ jobs:
       resource_class: "<<parameters.resource_class>>"
       docker_layer_caching: true # we rely on this for faster builds, and actively warm it up for builds with common stages
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           command: git submodule update --init
       - attach_workspace:
@@ -609,7 +676,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -659,7 +726,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - run:
@@ -737,7 +804,7 @@ jobs:
         type: string
         default: ci
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -796,7 +863,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: large
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -859,7 +926,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
@@ -900,7 +967,7 @@ jobs:
     machine:
       image: <<pipeline.parameters.base_image>>
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: Install ripgrep
           command: sudo apt-get install -y ripgrep
@@ -924,7 +991,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - check-changed:
           patterns: "<<parameters.package_name>>"
       - attach_workspace:
@@ -949,7 +1016,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: run Go linter
           command: |
@@ -988,7 +1055,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace:
           at: "."
       - run:
@@ -1056,7 +1123,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: Install tools
           command: |
@@ -1078,7 +1145,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - restore_cache:
           name: Restore cannon prestate cache
           key: cannon-prestate-{{ checksum "./cannon/bin/cannon" }}-{{ checksum "op-program/bin/op-program-client.elf" }}
@@ -1103,7 +1170,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - setup_remote_docker
       - run:
           name: Build prestates
@@ -1118,7 +1185,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - attach_workspace:
           at: "."
       - gcp-cli/install
@@ -1163,7 +1230,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - setup_remote_docker
       - run: make -C op-program verify-reproducibility
       - notify-failures-on-develop:
@@ -1173,7 +1240,7 @@ jobs:
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - setup_remote_docker
       - run:
           name: Build cannon
@@ -1240,7 +1307,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: verify-sepolia
           command: |
@@ -1253,7 +1320,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: compat-sepolia
           command: |
@@ -1264,7 +1331,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - check-changed:
           patterns: op-node
       - run:
@@ -1275,7 +1342,7 @@ jobs:
     machine: true
     resource_class: qkc/ax101
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - check-changed:
           patterns: op-service
       - run:
@@ -1287,7 +1354,7 @@ jobs:
       - image: <<pipeline.parameters.default_docker_image>>
     resource_class: xlarge
     steps:
-      - utils/checkout-with-mise
+      - checkout
       - install-contracts-dependencies
       - check-changed:
           no_go_deps: "true"
@@ -1324,7 +1391,7 @@ jobs:
           oidc_token_file_path: /tmp/oidc_token.json
           project_id: GCP_TOOLS_ARTIFACTS_PROJECT_ID
           service_account_email: GCP_CONTRACTS_PUBLISHER_SERVICE_ACCOUNT_EMAIL
-      - utils/checkout-with-mise
+      - checkout
       - install-contracts-dependencies
       - run:
           name: Pull artifacts
@@ -1359,7 +1426,7 @@ jobs:
       - gcp-oidc-authenticate:
           gcp_cred_config_file_path: /tmp/gcp_cred_config.json
           oidc_token_file_path: /tmp/oidc_token.json
-      - utils/checkout-with-mise
+      - checkout
       - run:
           name: Configure Docker
           command: |
@@ -1393,6 +1460,8 @@ workflows:
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
     jobs:
+      - initialize:
+          name: checkout-and-init-mise
       - contracts-bedrock-build:
           name: contracts-bedrock-build
           # Build with just core + script contracts.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ orbs:
   slack: circleci/slack@4.10.1
   shellcheck: circleci/shellcheck@3.2.0
   codecov: codecov/codecov@5.0.3
-  utils: ethereum-optimism/circleci-utils@1.0.8
+  utils: karlb/circleci-utils@0.1.0
 
 commands:
   gcp-oidc-authenticate:
@@ -143,7 +143,7 @@ commands:
           channel: << parameters.channel >>
           event: fail
           template: basic_fail_1
-          branch_pattern: develop
+          branch_pattern: op-es
           mentions: "<< parameters.mentions >>"
 
   run-contracts-check:
@@ -269,7 +269,7 @@ jobs:
 
   diff-asterisc-bytecode:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - run:
@@ -536,7 +536,7 @@ jobs:
                   - "<<parameters.release>>"
               - and:
                   - "<<parameters.publish>>"
-                  - equal: [develop, << pipeline.git.branch >>]
+                  - equal: [op-es, << pipeline.git.branch >>]
           steps:
             - gcp-oidc-authenticate:
                 service_account_email: GCP_SERVICE_ATTESTOR_ACCOUNT_EMAIL
@@ -613,7 +613,7 @@ jobs:
       - check-changed:
           patterns: contracts-bedrock
       - run:
-          name: Check if target branch is develop
+          name: Check if target branch is op-es
           command: |
             # Get PR number from CIRCLE_PULL_REQUEST
             PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | rev | cut -d/ -f1 | rev)
@@ -621,9 +621,9 @@ jobs:
             # Use GitHub API to get target branch
             TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .base.ref)
 
-            # If the target branch is not develop, do not run this check
-            if [ "$TARGET_BRANCH" != "develop" ]; then
-              echo "Target branch is not develop, skipping frozen files check"
+            # If the target branch is not op-es, do not run this check
+            if [ "$TARGET_BRANCH" != "op-es" ]; then
+              echo "Target branch is not op-es, skipping frozen files check"
               exit 0
             fi
       - run:
@@ -1074,7 +1074,7 @@ jobs:
 
   cannon-prestate-quick:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - restore_cache:
@@ -1114,7 +1114,7 @@ jobs:
 
   publish-cannon-prestates:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - attach_workspace:
@@ -1249,7 +1249,7 @@ jobs:
 
   op-program-compat:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - run:
@@ -1260,7 +1260,7 @@ jobs:
 
   check-generated-mocks-op-node:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - check-changed:
@@ -1271,7 +1271,7 @@ jobs:
 
   check-generated-mocks-op-service:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - utils/checkout-with-mise
       - check-changed:
@@ -1314,7 +1314,7 @@ jobs:
 
   publish-contract-artifacts:
     machine: true
-    resource_class: ethereum-optimism/latitude-1
+    resource_class: qkc/ax101
     steps:
       - gcp-cli/install
       - gcp-oidc-authenticate:
@@ -1409,7 +1409,7 @@ workflows:
       - contracts-bedrock-tests:
           # Heavily fuzz any fuzz tests within added or modified test files.
           name: contracts-bedrock-tests-heavy-fuzz-modified
-          test_list: git diff origin/develop...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
+          test_list: git diff origin/op-es...HEAD --name-only --diff-filter=AM -- './test/**/*.t.sol' | sed 's|packages/contracts-bedrock/||'
           test_timeout: 3h
           test_profile: ciheavy
       - contracts-bedrock-coverage:
@@ -1703,7 +1703,7 @@ workflows:
     when:
       and:
         - or:
-            - equal: ["develop", <<pipeline.git.branch>>]
+            - equal: ["op-es", <<pipeline.git.branch>>]
             - equal: [true, <<pipeline.parameters.fault_proofs_dispatch>>]
         - not:
             equal: [scheduled_pipeline, << pipeline.trigger_source >>]
@@ -1743,7 +1743,7 @@ workflows:
           filters:
             branches:
               only:
-                - develop
+                - op-es
 
   # develop-kontrol-tests:
   #   when:


### PR DESCRIPTION
Changes include the command of checkout with mise, referring to https://github.com/ethereum-optimism/circleci-utils/blob/main/orb/src/commands/checkout-with-mise.yml. 

The reason we make this change is that the org of `ethereum-optimism/circleci-utils@1.0.8` is not available in the circleci project.

In the command a cache is managed to avoid reinstallations of the same versions.

Other changes include the runner and branch name.