### PR TITLE
add cannon64 prestate to make `TestGetReleases` pass

### DIFF
--- a/op-program/prestates/releases.json
+++ b/op-program/prestates/releases.json
@@ -2,6 +2,11 @@
   {
     "version": "0.1",
     "hash": "0x03a9deca8ceb15b1bfe60c98bed2305353b33859a2ffa4dd8c2f5641c4d99a23",
+    "type": "cannon64"
+  },
+  {
+    "version": "0.1",
+    "hash": "0x0319f8ab85189655821325a8367aa56a1848e0845403d83e7426fad8a0224010",
     "governanceApproved": true
   }
 ]


### PR DESCRIPTION
This PR adds the cannon64 prestate for the [0.1 release](https://github.com/ethstorage/optimism/releases/tag/op-program%2Fv0.1) to make `TestGetReleases ` pass.