### PR TITLE
fix bug in block processor

### DIFF
--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -96,7 +96,8 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 		vmenv := vm.NewEVM(context, statedb, provider.Config(), vm.Config{PrecompileOverrides: precompileOverrides})
 		return vmenv
 	}
-	vmenv := mkEVM()
+	var vmenv *vm.EVM
+
 	if h.ParentBeaconRoot != nil {
 		if provider.Config().IsCancun(header.Number, header.Time) {
 			// Blob tx not supported on optimism chains but fields must be set when Cancun is active.
@@ -111,7 +112,10 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 			}
 			header.ExcessBlobGas = &excessBlobGas
 		}
+		vmenv = mkEVM()
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv)
+	} else {
+		vmenv = mkEVM()
 	}
 	if provider.Config().IsPrague(header.Number, header.Time) {
 		core.ProcessParentBlockHash(header.ParentHash, vmenv)

--- a/op-program/client/l2/engineapi/block_processor.go
+++ b/op-program/client/l2/engineapi/block_processor.go
@@ -112,6 +112,7 @@ func NewBlockProcessorFromHeader(provider BlockDataProvider, h *types.Header) (*
 			}
 			header.ExcessBlobGas = &excessBlobGas
 		}
+		// core.NewEVMBlockContext need to be called after the blob gas fields are set
 		vmenv = mkEVM()
 		core.ProcessBeaconBlockRoot(*header.ParentBeaconRoot, vmenv)
 	} else {


### PR DESCRIPTION
Finally found the bug, fixes https://github.com/QuarkChain/optimism/issues/15.

This PR makes `NewBlockProcessorFromHeader` call `mkEVM` after the blob gas fields are set, so that `core.NewEVMBlockContext` can correctly set a `blobBaseFee` [here](https://github.com/ethereum-optimism/op-geth/blob/963ab50dff5f88c50cc76fb6070cdb0d5f53fa8e/core/evm.go#L65), otherwise it'll be `nil`.

Note that even OP hasn't enabled blob tx, these fields are require as long as `CanCun` is enabled, as can be seen [here](https://github.com/ethereum-optimism/op-geth/blob/963ab50dff5f88c50cc76fb6070cdb0d5f53fa8e/miner/worker.go#L304-L312).