### PR TITLE
CircieCI: fix contracts-bedrock-frozen-code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -668,31 +668,25 @@ jobs:
 
   contracts-bedrock-frozen-code:
     machine: true
-    resource_class: qkc/ax101
+    resource_class: ethereum-optimism/latitude-1
     steps:
-      - checkout-with-mise
+      - utils/checkout-with-mise
       - attach_workspace: { at: "." }
       - install-contracts-dependencies
       - check-changed:
           patterns: contracts-bedrock
       - run:
-          name: Check if target branch is op-es
+          name: Check if target branch is develop
           command: |
-            # Not triggered by a PR
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-                echo "No pull request, skipping frozen files check"
-                exit 0
-            fi
-
             # Get PR number from CIRCLE_PULL_REQUEST
             PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | rev | cut -d/ -f1 | rev)
 
             # Use GitHub API to get target branch
-            TARGET_BRANCH=$(curl -s "https://api.github.com/repos/QuarkChain/optimism/pulls/${PR_NUMBER}" | jq -r .base.ref)
+            TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .base.ref)
 
-            # If the target branch is not op-es, do not run this check
-            if [ "$TARGET_BRANCH" != "op-es" ]; then
-              echo "Target branch is not op-es, skipping frozen files check"
+            # If the target branch is not develop, do not run this check
+            if [ "$TARGET_BRANCH" != "develop" ]; then
+              echo "Target branch is not develop, skipping frozen files check"
               exit 0
             fi
       - run:
@@ -1494,9 +1488,10 @@ workflows:
       - contracts-bedrock-checks:
           requires:
             - contracts-bedrock-build
-      - contracts-bedrock-frozen-code:
-          requires:
-            - contracts-bedrock-build
+      # Skip frozen check for op-es
+      # - contracts-bedrock-frozen-code:
+      #     requires:
+      #       - contracts-bedrock-build
       - diff-asterisc-bytecode
       - semgrep-scan:
           name: semgrep-scan-local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -678,6 +678,12 @@ jobs:
       - run:
           name: Check if target branch is op-es
           command: |
+            # Not triggered by a PR
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+                echo "No pull request, skipping frozen files check"
+                exit 0
+            fi
+
             # Get PR number from CIRCLE_PULL_REQUEST
             PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | rev | cut -d/ -f1 | rev)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -688,7 +688,7 @@ jobs:
             PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | rev | cut -d/ -f1 | rev)
 
             # Use GitHub API to get target branch
-            TARGET_BRANCH=$(curl -s "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${PR_NUMBER}" | jq -r .base.ref)
+            TARGET_BRANCH=$(curl -s "https://api.github.com/repos/QuarkChain/optimism/pulls/${PR_NUMBER}" | jq -r .base.ref)
 
             # If the target branch is not op-es, do not run this check
             if [ "$TARGET_BRANCH" != "op-es" ]; then


### PR DESCRIPTION
If no PR found, the job fails with `Exited with code exit status 3`. 

This fix checks that the PR exists and uses the correct repo URL.