### PR TITLE
CircleCI: fix test_cannotReinitialize_succeeds

### DIFF
--- a/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
@@ -66,7 +66,7 @@ contract GasBenchMark_L1Block_SetValuesEcotone is GasBenchMark_L1Block {
         SafeCall.call({ _target: address(l1Block), _calldata: setValuesCalldata });
 
         // Assert
-        assertLt(vm.lastCallGas().gasTotalUsed, 161_000);
+        assertLt(vm.lastCallGas().gasTotalUsed, 160_000);
     }
 }
 

--- a/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
+++ b/packages/contracts-bedrock/test/universal/BenchmarkTest.t.sol
@@ -66,7 +66,7 @@ contract GasBenchMark_L1Block_SetValuesEcotone is GasBenchMark_L1Block {
         SafeCall.call({ _target: address(l1Block), _calldata: setValuesCalldata });
 
         // Assert
-        assertLt(vm.lastCallGas().gasTotalUsed, 160_000);
+        assertLt(vm.lastCallGas().gasTotalUsed, 161_000);
     }
 }
 

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -241,10 +241,18 @@ contract Initializer_Test is CommonTest {
                 )
             })
         );
-        // SoulGasToken
+        // SoulGasTokenImpl
         contracts.push(
             InitializeableContract({
-                name: "SoulGasToken",
+                name: "SoulGasTokenImpl",
+                target: address(soulGasToken),
+                initCalldata: abi.encodeCall(soulGasToken.initialize, ("SoulGasToken", "SGT", address(0)))
+            })
+        );
+        // SoulGasTokenProxy
+        contracts.push(
+            InitializeableContract({
+                name: "SoulGasTokenProxy",
                 target: address(soulGasToken),
                 initCalldata: abi.encodeCall(soulGasToken.initialize, ("SoulGasToken", "SGT", address(0)))
             })
@@ -427,13 +435,9 @@ contract Initializer_Test is CommonTest {
             InitializeableContract memory _contract = contracts[i];
             string memory deploymentName = _getRealContractName(_contract.name);
 
-            string memory contractName = deploymentName;
-            if (!LibString.eq(deploymentName, "SoulGasToken")) {
-                contractName = _removeSuffix(deploymentName);
-            }
             // Assert that the contract is already initialized.
             assertTrue(
-                ForgeArtifacts.isInitialized({ _name: contractName, _address: _contract.target }),
+                ForgeArtifacts.isInitialized({ _name: _removeSuffix(deploymentName), _address: _contract.target }),
                 "Initializable: contract is not initialized"
             );
 

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -427,9 +427,13 @@ contract Initializer_Test is CommonTest {
             InitializeableContract memory _contract = contracts[i];
             string memory deploymentName = _getRealContractName(_contract.name);
 
+            string memory contractName = deploymentName;
+            if (!LibString.eq(deploymentName, "SoulGasToken")) {
+                contractName = _removeSuffix(deploymentName);
+            }
             // Assert that the contract is already initialized.
             assertTrue(
-                ForgeArtifacts.isInitialized({ _name: _removeSuffix(deploymentName), _address: _contract.target }),
+                ForgeArtifacts.isInitialized({ _name: contractName, _address: _contract.target }),
                 "Initializable: contract is not initialized"
             );
 

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -245,7 +245,7 @@ contract Initializer_Test is CommonTest {
         contracts.push(
             InitializeableContract({
                 name: "SoulGasTokenImpl",
-                target: address(soulGasToken),
+                target: EIP1967Helper.getImplementation(address(soulGasToken)),
                 initCalldata: abi.encodeCall(soulGasToken.initialize, ("SoulGasToken", "SGT", address(0)))
             })
         );


### PR DESCRIPTION
Addressing part of https://github.com/QuarkChain/optimism/issues/14, the error caused by `_removeSuffix` used on `SoulGasToken`.

```log
Encountered 1 failing test in test/vendor/Initializable.t.sol:Initializer_Test
[FAIL: FfiFailed("No output from Command: bash -c ls -1 --color=never /root/dl/circleci/optimism/packages/contracts-bedrock/forge-artifacts/.sol | jq -R -s -c 'split(\"\n\") | map(select(length > 0))' ")] test_cannotReinitialize_succeeds() (gas: 18842418)
```