### PR TITLE
enable sgt & l2blob for simple devnet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -35,3 +35,7 @@
 [submodule "packages/contracts-bedrock/lib/superchain-registry"]
 	path = packages/contracts-bedrock/lib/superchain-registry
 	url = https://github.com/ethereum-optimism/superchain-registry
+[submodule "op-geth"]
+	path = op-geth
+	url = https://github.com/QuarkChain/op-geth
+	branch = op-es

--- a/kurtosis-devnet/justfile
+++ b/kurtosis-devnet/justfile
@@ -41,7 +41,7 @@ op-proposer-image TAG='op-proposer:devnet': (_docker_build_stack TAG "op-propose
 op-supervisor-image TAG='op-supervisor:devnet': (_docker_build_stack TAG "op-supervisor-target")
 op-wheel-image TAG='op-wheel:devnet': (_docker_build_stack TAG "op-wheel-target")
 
-KURTOSIS_PACKAGE := "github.com/ethpandaops/optimism-package"
+KURTOSIS_PACKAGE := "github.com/QuarkChain/optimism-package"
 
 # Devnet template recipe
 devnet TEMPLATE_FILE DATA_FILE="" NAME="":

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -2,7 +2,7 @@ optimism_package:
   chains:
     - participants:
       - el_type: op-geth
-        el_image: ""
+        el_image: {{ localDockerImage "op-node" }}
         el_log_level: ""
         el_extra_env_vars: {}
         el_extra_labels: {}
@@ -62,6 +62,7 @@ optimism_package:
     global_deploy_overrides:
       faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
       useSoulGasToken: true
+      soulGasTokenBlock: 0
       isSoulBackedByNative: true
       l2GenesisBlobTimeOffset: "0x0"
   global_log_level: "info"
@@ -69,6 +70,9 @@ optimism_package:
   global_tolerations: []
   persistent: false
 ethereum_package:
+  participants:
+    - el_type: geth
+      cl_type: teku
   network_params:
     preset: minimal
     genesis_delay: 5

--- a/kurtosis-devnet/simple.yaml
+++ b/kurtosis-devnet/simple.yaml
@@ -61,6 +61,9 @@ optimism_package:
     l2_artifacts_locator: {{ localContractArtifacts "l2" }}
     global_deploy_overrides:
       faultGameAbsolutePrestate: {{ localPrestate.Hashes.prestate }}
+      useSoulGasToken: true
+      isSoulBackedByNative: true
+      l2GenesisBlobTimeOffset: "0x0"
   global_log_level: "info"
   global_node_selectors: {}
   global_tolerations: []

--- a/ops/docker/op-stack-go/Dockerfile
+++ b/ops/docker/op-stack-go/Dockerfile
@@ -138,6 +138,10 @@ FROM --platform=$BUILDPLATFORM builder AS dac-server-builder
 ARG OP_NODE_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd da-server && go build -o da-server main.go
 
+FROM --platform=$BUILDPLATFORM builder AS op-geth-builder
+ARG OP_NODE_VERSION=v0.0.0
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd op-geth && CGO_ENABLED=0 make geth
+
 FROM --platform=$BUILDPLATFORM builder AS op-dripper-builder
 ARG OP_DRIPPER_VERSION=v0.0.0
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build cd op-dripper && make op-dripper  \
@@ -160,6 +164,7 @@ FROM $TARGET_BASE_IMAGE AS op-node-target
 COPY --from=op-node-builder /app/op-node/bin/op-node /usr/local/bin/
 COPY --from=dac-server-builder /app/da-server/da-server /usr/local/bin/
 COPY --from=dac-server-builder /app/da-server/default.json /usr/local/bin/
+COPY --from=op-geth-builder /app/op-geth/build/bin/geth /usr/local/bin/
 CMD ["op-node"]
 
 # Make the kona docker image published by upstream available as a source to copy kona and asterisc from.

--- a/ops/docker/op-stack-go/Dockerfile.dockerignore
+++ b/ops/docker/op-stack-go/Dockerfile.dockerignore
@@ -20,6 +20,7 @@
 !/op-wheel
 !/op-alt-da
 !/da-server
+!/op-geth
 !/go.mod
 !/go.sum
 !/justfiles


### PR DESCRIPTION
This PR finishes item 1 and 2 of https://github.com/QuarkChain/optimism/issues/26 .

Support for dac server will be added in a separate PR.

To spin up the devnet(precondition: docker server is up):

```bash
cd kurtosis-devnet
just simple-devnet
```
(It's much slower than before, so I only do it on dev-machine now.)

It'll start many containers, one for each component.

To tear down:

```bash
kurtosis enclave rm -f simple-devnet
```