### PR TITLE
CircleCI: fix sanitize-op-program: sudo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1118,6 +1118,12 @@ jobs:
     resource_class: qkc/ax101
     steps:
       - checkout-with-mise
+      # Already installed on qkc/ax101
+      # - run:
+      #     name: Install tools
+      #     command: |
+      #       sudo apt-get update
+      #       sudo apt-get install -y binutils-mips-linux-gnu
       - run:
           name: Build cannon
           command: make cannon

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1119,11 +1119,6 @@ jobs:
     steps:
       - checkout-with-mise
       - run:
-          name: Install tools
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y binutils-mips-linux-gnu
-      - run:
           name: Build cannon
           command: make cannon
       - run:


### PR DESCRIPTION
Fix error when trying to exectute sudo commands.
```log
[sudo] password for circleci: 
sudo: no password was provided
sudo: a password is required

Exited with code exit status 1
```
Full log can be found [here](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/23/workflows/dfbbfd22-250d-4e7e-9b7e-f9f1bfeecf5f/jobs/395)

The solution is to install the tools manually on AX101, and remove the installation script.