### PR TITLE
dynamic SGT

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -257,7 +257,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/Quarkchain/op-geth v0.0.0-20250217080034-97596a48ef97
+replace github.com/ethereum/go-ethereum => github.com/Quarkchain/op-geth v0.0.0-20250327014517-83933ea74589
 
 // replace github.com/ethereum/go-ethereum => ../op-geth
 

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Quarkchain/op-geth v0.0.0-20250217080034-97596a48ef97 h1:BiuY+UjSYTCxn4lBX0hnrFV0BDMuZCNF1IqWziw3Jf8=
-github.com/Quarkchain/op-geth v0.0.0-20250217080034-97596a48ef97/go.mod h1:OMpyVMMy5zpAAHlR5s/aGbXRk+7cIKczUEIJj54APbY=
+github.com/Quarkchain/op-geth v0.0.0-20250327014517-83933ea74589 h1:9Xb7kDt81XtXK6hnTz1HtfFZDP1GMLCoE3Lzbhwahz0=
+github.com/Quarkchain/op-geth v0.0.0-20250327014517-83933ea74589/go.mod h1:OMpyVMMy5zpAAHlR5s/aGbXRk+7cIKczUEIJj54APbY=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -853,6 +853,8 @@ type L1DependenciesConfig struct {
 type SoulGasTokenConfig struct {
 	// UseSoulGasToken is a flag that indicates if the system is using SoulGasToken
 	UseSoulGasToken bool `json:"useSoulGasToken,omitempty"`
+	// The height of the block at which the SoulGasToken is activated.
+	SoulGasTokenBlock uint64 `json:"soulGasTokenBlock,omitempty"`
 	// IsSoulBackedByNative is a flag that indicates if the SoulGasToken is backed by native.
 	// Only effective when UseSoulGasToken is true.
 	IsSoulBackedByNative bool `json:"isSoulBackedByNative,omitempty"`

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -40,6 +40,10 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 	}
 
 	l1StartTime := l1StartHeader.Time
+	var soulGasTokenBlock *uint64
+	if config.UseSoulGasToken {
+		soulGasTokenBlock = u64ptr(config.SoulGasTokenBlock)
+	}
 
 	optimismChainConfig := params.ChainConfig{
 		ChainID:                 new(big.Int).SetUint64(config.L2ChainID),
@@ -78,7 +82,7 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 			EIP1559Elasticity:        eip1559Elasticity,
 			EIP1559DenominatorCanyon: &eip1559DenomCanyon,
 			IsSoulBackedByNative:     config.IsSoulBackedByNative,
-			UseSoulGasToken:          config.UseSoulGasToken,
+			SoulGasTokenBlock:        soulGasTokenBlock,
 		},
 	}
 

--- a/op-e2e/actions/sgt/sgt_test.go
+++ b/op-e2e/actions/sgt/sgt_test.go
@@ -1,0 +1,115 @@
+package sgt
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-e2e/actions/helpers"
+	"github.com/ethereum-optimism/optimism/op-e2e/bindings"
+	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils"
+	"github.com/ethereum-optimism/optimism/op-service/predeploys"
+	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicSGT(gt *testing.T) {
+	t := helpers.NewDefaultTesting(gt)
+	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
+	dp.DeployConfig.UseSoulGasToken = true
+	dp.DeployConfig.SoulGasTokenBlock = 100
+	sd := e2eutils.Setup(t, dp, helpers.DefaultAlloc)
+	log := testlog.Logger(t, log.LevelDebug)
+	miner, engine, sequencer := helpers.SetupSequencerTest(t, sd, log)
+
+	cl := engine.EthClient()
+	depositSGT(gt, engine, sd, dp, dp.Addresses.Alice, e2eutils.Ether(2))
+
+	sequencer.ActL2PipelineFull(t)
+
+	genesisTime := sequencer.L2Unsafe().Time
+
+	// Make L2 block
+	sequencer.ActL2StartBlock(t)
+	engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
+	sequencer.ActL2EndBlock(t)
+
+	// Alice makes a L2 tx
+
+	balance1, err := cl.BalanceAt(t.Ctx(), dp.Addresses.Alice, nil)
+	require.NoError(t, err)
+	n, err := cl.PendingNonceAt(t.Ctx(), dp.Addresses.Alice)
+	require.NoError(t, err)
+	signer := types.LatestSigner(sd.L2Cfg.Config)
+	tx := types.MustSignNewTx(dp.Secrets.Alice, signer, &types.DynamicFeeTx{
+		ChainID:   sd.L2Cfg.Config.ChainID,
+		Nonce:     n,
+		GasTipCap: big.NewInt(2 * params.GWei),
+		GasFeeCap: new(big.Int).Add(miner.L1Chain().CurrentBlock().BaseFee, big.NewInt(2*params.GWei)),
+		Gas:       params.TxGas,
+		To:        &dp.Addresses.Bob,
+	})
+	require.NoError(t, cl.SendTransaction(t.Ctx(), tx))
+
+	sequencer.ActL2PipelineFull(t)
+
+	// Make L2 block
+	sequencer.ActL2StartBlock(t)
+	engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
+	sequencer.ActL2EndBlock(t)
+
+	balance2, err := cl.BalanceAt(t.Ctx(), dp.Addresses.Alice, nil)
+	require.NoError(t, err)
+	// Check that the balance is different
+	// because the SGT is not active yet
+	require.True(t, balance2.Cmp(balance1) < 0)
+
+	// advance to the block where the SGT is active
+	sequencer.ActBuildL2ToTime(t, genesisTime+dp.DeployConfig.L2BlockTime*dp.DeployConfig.SoulGasTokenBlock)
+
+	// Alice makes a L2 tx
+	n, err = cl.PendingNonceAt(t.Ctx(), dp.Addresses.Alice)
+	require.NoError(t, err)
+	tx = types.MustSignNewTx(dp.Secrets.Alice, signer, &types.DynamicFeeTx{
+		ChainID:   sd.L2Cfg.Config.ChainID,
+		Nonce:     n,
+		GasTipCap: big.NewInt(2 * params.GWei),
+		GasFeeCap: new(big.Int).Add(miner.L1Chain().CurrentBlock().BaseFee, big.NewInt(2*params.GWei)),
+		Gas:       params.TxGas,
+		To:        &dp.Addresses.Bob,
+	})
+	require.NoError(t, cl.SendTransaction(t.Ctx(), tx))
+
+	sequencer.ActL2PipelineFull(t)
+
+	// Make L2 block
+	sequencer.ActL2StartBlock(t)
+	engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
+	sequencer.ActL2EndBlock(t)
+
+	balance3, err := cl.BalanceAt(t.Ctx(), dp.Addresses.Alice, nil)
+	require.NoError(t, err)
+
+	// Check that the balance is the same as before
+	// because the SGT is active
+	require.True(t, balance3.Cmp(balance2) == 0)
+}
+
+func depositSGT(t *testing.T, engine *helpers.L2Engine, sd *e2eutils.SetupData, dp *e2eutils.DeployParams, target common.Address, depositSgtValue *big.Int) {
+
+	sgtAddr := predeploys.SoulGasTokenAddr
+	sgtContract, err := bindings.NewSoulGasToken(sgtAddr, engine.EthClient())
+	require.NoError(t, err)
+
+	txOpts, err := bind.NewKeyedTransactorWithChainID(dp.Secrets.Alice, sd.L2Cfg.Config.ChainID)
+	require.NoError(t, err)
+	txOpts.Value = depositSgtValue
+
+	_, err = sgtContract.BatchDepositForAll(txOpts, []common.Address{target}, depositSgtValue)
+	require.NoError(t, err)
+
+}

--- a/op-e2e/actions/sgt/sgt_test.go
+++ b/op-e2e/actions/sgt/sgt_test.go
@@ -55,8 +55,6 @@ func TestDynamicSGT(gt *testing.T) {
 	})
 	require.NoError(t, cl.SendTransaction(t.Ctx(), tx))
 
-	sequencer.ActL2PipelineFull(t)
-
 	// Make L2 block
 	sequencer.ActL2StartBlock(t)
 	engine.ActL2IncludeTx(dp.Addresses.Alice)(t)
@@ -83,8 +81,6 @@ func TestDynamicSGT(gt *testing.T) {
 		To:        &dp.Addresses.Bob,
 	})
 	require.NoError(t, cl.SendTransaction(t.Ctx(), tx))
-
-	sequencer.ActL2PipelineFull(t)
 
 	// Make L2 block
 	sequencer.ActL2StartBlock(t)

--- a/op-e2e/sgt/sgt_test.go
+++ b/op-e2e/sgt/sgt_test.go
@@ -9,7 +9,7 @@ import (
 
 	op_e2e "github.com/ethereum-optimism/optimism/op-e2e"
 	"github.com/ethereum-optimism/optimism/op-e2e/e2eutils/wait"
-	"github.com/ethereum-optimism/optimism/op-e2e/faultproofs"
+	"github.com/ethereum-optimism/optimism/op-e2e/system/e2esys"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testutils"
 
@@ -29,7 +29,8 @@ var (
 
 func TestSGTDepositFunctionSuccess(t *testing.T) {
 	op_e2e.InitParallel(t)
-	sys, _ := faultproofs.StartFaultDisputeSystem(t)
+	sgtBlock := uint64(0)
+	sys := startSystemWithSGT(&sgtBlock, t)
 	t.Cleanup(sys.Close)
 	ctx := context.Background()
 
@@ -38,11 +39,31 @@ func TestSGTDepositFunctionSuccess(t *testing.T) {
 	_, _, _ = setUpTestAccount(t, ctx, 0, sgt, depositSgtValue, big.NewInt(0))
 }
 
+func startSystemWithSGT(sgtBlock *uint64, t *testing.T) *e2esys.System {
+	cfg := e2esys.DefaultSystemConfig(t)
+	delete(cfg.Nodes, "verifier")
+	_, ok := cfg.Nodes["sequencer"]
+	require.True(t, ok, "sequencer is required")
+
+	if sgtBlock != nil {
+		cfg.DeployConfig.UseSoulGasToken = true
+		cfg.DeployConfig.SoulGasTokenBlock = *sgtBlock
+	} else {
+		cfg.DeployConfig.UseSoulGasToken = false
+	}
+	// Disable proposer creating fast games automatically - required games are manually created
+	cfg.DisableProposer = true
+	sys, err := cfg.Start(t)
+	require.Nil(t, err, "Error starting up system")
+	return sys
+}
+
 // Diverse test scenarios to verify that the SoulGasToken(sgt) is utilized for gas payment firstly,
 // unless there is insufficient sgt balance, in which case the native balance will be used instead.
 func TestSGTAsGasPayment(t *testing.T) {
 	op_e2e.InitParallel(t)
-	sys, _ := faultproofs.StartFaultDisputeSystem(t)
+	sgtBlock := uint64(0)
+	sys := startSystemWithSGT(&sgtBlock, t)
 	t.Cleanup(sys.Close)
 	ctx := context.Background()
 

--- a/op-e2e/system/e2esys/setup.go
+++ b/op-e2e/system/e2esys/setup.go
@@ -85,13 +85,6 @@ var (
 	genesisTime      = hexutil.Uint64(0)
 )
 
-func DefaultSystemConfigForSoulGasToken(t *testing.T, enable, isBackedByNative bool) SystemConfig {
-	config := DefaultSystemConfig(t)
-	config.UseSoulGasToken = enable
-	config.IsSoulBackedByNative = isBackedByNative
-	return config
-}
-
 type SystemConfigOpts struct {
 	AllocType config.AllocType
 }


### PR DESCRIPTION
This PR adds support for dynamic SGT.

For solidity compatibility, this PR keeps the `UseSoulGasToken bool` field in DeployConfig, and additionally adds a `SoulGasTokenBlock uint64` to indicate when to activate SGT. The two fields combined serve the same purpose as the `SoulGasTokenBlock *uint64`  in op-geth.

An action test for SGT is added that checks that only when SGT is activated will the gas fee be conducted from it.