### PR TITLE
use erc7201 for L1Block historyHashes

### DIFF
--- a/packages/contracts-bedrock/snapshots/storageLayout/L1Block.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1Block.json
@@ -75,12 +75,5 @@
     "offset": 0,
     "slot": "7",
     "type": "uint256"
-  },
-  {
-    "bytes": "262144",
-    "label": "historyHashes",
-    "offset": 0,
-    "slot": "8",
-    "type": "bytes32[8192]"
   }
 ]

--- a/packages/contracts-bedrock/snapshots/storageLayout/L1BlockInterop.json
+++ b/packages/contracts-bedrock/snapshots/storageLayout/L1BlockInterop.json
@@ -77,17 +77,10 @@
     "type": "uint256"
   },
   {
-    "bytes": "262144",
-    "label": "historyHashes",
-    "offset": 0,
-    "slot": "8",
-    "type": "bytes32[8192]"
-  },
-  {
     "bytes": "64",
     "label": "dependencySet",
     "offset": 0,
-    "slot": "8200",
+    "slot": "8",
     "type": "struct EnumerableSet.UintSet"
   }
 ]

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -87,10 +87,23 @@ contract L1Block is ISemver {
         is_ = false;
     }
 
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L1Block.HistoryHashesStorage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant _L1BLOCK_HISTORY_HASHES_LOCATION =
+        0xb6e35d777715793a0808adb4ab3d51fc56065457feaf3a18bd958afef33bef00;
     /// @notice size of historyHashes.
     uint256 internal constant HISTORY_SIZE = 8192;
-    /// @notice The 8191 history L1 blockhashes and 1 latest L1 blockhash.
-    bytes32[HISTORY_SIZE] internal historyHashes;
+    /// @custom:storage-location erc7201:openzeppelin.storage.L1Block.HistoryHashesStorage
+    struct HistoryHashesStorage {
+        /// @notice The 8191 history L1 blockhashes and 1 latest L1 blockhash.
+        bytes32[HISTORY_SIZE] historyHashes;
+    }
+
+
+    function _getHistoryHashesStorage() private pure returns (HistoryHashesStorage storage $) {
+        assembly {
+            $.slot := _L1BLOCK_HISTORY_HASHES_LOCATION
+        }
+    }
 
     /// @custom:legacy
     /// @notice Updates the L1 block values.
@@ -172,7 +185,8 @@ contract L1Block is ISemver {
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
 
-        historyHashes[number % HISTORY_SIZE] = hash;
+        HistoryHashesStorage storage $ = _getHistoryHashesStorage();
+        $.historyHashes[number % HISTORY_SIZE] = hash;
     }
 
     /// @custom:legacy
@@ -191,7 +205,8 @@ contract L1Block is ISemver {
             lower = upper - HISTORY_SIZE + 1;
         }
         if (_historyNumber >= lower && _historyNumber < upper) {
-            return historyHashes[_historyNumber % HISTORY_SIZE];
+            HistoryHashesStorage storage $ = _getHistoryHashesStorage();
+            return $.historyHashes[_historyNumber % HISTORY_SIZE];
         } else {
             return bytes32(0);
         }


### PR DESCRIPTION
When reviewing the contract changes, I found it's better to use erc7201 to avoid slot collision with upstream.

(After this PR is merged, I'll prepare a `mainnet_contracts_v1.8.0` branch which will contain our contract changes based on v1.8.0.)