### PR TITLE
re-apply all contract/op-deployer changes on top of v1.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -250,7 +250,7 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ethereum/go-ethereum v1.14.11 => github.com/ethereum-optimism/op-geth v1.101411.1-rc.5
+replace github.com/ethereum/go-ethereum v1.14.11 => github.com/Quarkchain/op-geth v0.0.0-20250421124107-593289df5126
 
 //replace github.com/ethereum/go-ethereum => ../go-ethereum
 

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Quarkchain/op-geth v0.0.0-20250421124107-593289df5126 h1:DbAS4Ua749z5tJGrqv2NtezyH1rMEnvME4NdMUJtI7Y=
+github.com/Quarkchain/op-geth v0.0.0-20250421124107-593289df5126/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
 github.com/VictoriaMetrics/fastcache v1.12.2 h1:N0y9ASrJ0F6h0QaC3o6uJb3NIZ9VKLjCM7NQbSmF7WI=
 github.com/VictoriaMetrics/fastcache v1.12.2/go.mod h1:AmC+Nzz1+3G2eCPapF6UcsnkThDcMsQicp4xDukwJYI=
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
@@ -187,8 +189,6 @@ github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/u
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3 h1:RWHKLhCrQThMfch+QJ1Z8veEq5ZO3DfIhZ7xgRP9WTc=
 github.com/ethereum-optimism/go-ethereum-hdwallet v0.1.3/go.mod h1:QziizLAiF0KqyLdNJYD7O5cpDlaFMNZzlxYNcWsJUxs=
-github.com/ethereum-optimism/op-geth v1.101411.1-rc.5 h1:LDSP85xTczjDYMBK0mOF5mzpZifLGz1TTW/6NgQsytc=
-github.com/ethereum-optimism/op-geth v1.101411.1-rc.5/go.mod h1:7S4pp8KHBmEmKkRjL1BPOc6jY9hW+64YeMUjR3RVLw4=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac h1:hCIrLuOPV3FJfMDvXeOhCC3uQNvFoMIIlkT2mN2cfeg=
 github.com/ethereum-optimism/superchain-registry/superchain v0.0.0-20240910145426-b3905c89e8ac/go.mod h1:XaVXL9jg8BcyOeugECgIUGa9Y3DjYJj71RHmb5qon6M=
 github.com/ethereum/c-kzg-4844 v1.0.0 h1:0X1LBXxaEtYD9xsyj9B9ctQEZIpnvVDeoBx8aHEwTNA=

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -354,6 +354,10 @@ type UpgradeScheduleDeployConfig struct {
 
 	// UseInterop is a flag that indicates if the system is using interop
 	UseInterop bool `json:"useInterop,omitempty"`
+
+	// L2GenesisBlobTimeOffset is the number of seconds after genesis block that the L2Blob hard fork activates.
+	// Set it to 0 to activate at genesis. Nil to disable L2Blob.
+	L2GenesisBlobTimeOffset *hexutil.Uint64 `json:"l2GenesisBlobTimeOffset,omitempty"`
 }
 
 var _ ConfigChecker = (*UpgradeScheduleDeployConfig)(nil)
@@ -474,6 +478,17 @@ func (d *UpgradeScheduleDeployConfig) HoloceneTime(genesisTime uint64) *uint64 {
 
 func (d *UpgradeScheduleDeployConfig) InteropTime(genesisTime uint64) *uint64 {
 	return offsetToUpgradeTime(d.L2GenesisInteropTimeOffset, genesisTime)
+}
+
+func (d *UpgradeScheduleDeployConfig) L2BlobTime(genesisTime uint64) *uint64 {
+	if d.L2GenesisBlobTimeOffset == nil {
+		return nil
+	}
+	v := uint64(0)
+	if offset := *d.L2GenesisBlobTimeOffset; offset > 0 {
+		v = genesisTime + uint64(offset)
+	}
+	return &v
 }
 
 func (d *UpgradeScheduleDeployConfig) AllocMode(genesisTime uint64) L2AllocsMode {
@@ -646,6 +661,8 @@ type L2InitializationConfig struct {
 	UpgradeScheduleDeployConfig
 	L2CoreDeployConfig
 	AltDADeployConfig
+	SoulGasTokenConfig
+	InboxContractConfig
 }
 
 func (d *L2InitializationConfig) Check(log log.Logger) error {
@@ -818,6 +835,23 @@ type L1DependenciesConfig struct {
 	ProtocolVersionsProxy common.Address `json:"protocolVersionsProxy"`
 }
 
+// SoulGasTokenConfig configures the SoulGasToken deployment to L2.
+type SoulGasTokenConfig struct {
+	// UseSoulGasToken is a flag that indicates if the system is using SoulGasToken
+	UseSoulGasToken bool `json:"useSoulGasToken,omitempty"`
+	// The height of the block at which the SoulGasToken is activated.
+	SoulGasTokenBlock uint64 `json:"soulGasTokenBlock,omitempty"`
+	// IsSoulBackedByNative is a flag that indicates if the SoulGasToken is backed by native.
+	// Only effective when UseSoulGasToken is true.
+	IsSoulBackedByNative bool `json:"isSoulBackedByNative,omitempty"`
+}
+
+// InboxContractConfig configures whether inbox contract is enabled.
+// If enabled, the batcher tx will be further filtered by tx status.
+type InboxContractConfig struct {
+	UseInboxContract bool `json:"useInboxContract,omitempty"`
+}
+
 // DependencyContext is the contextual configuration needed to verify the L1 dependencies,
 // used by DeployConfig.CheckAddresses.
 type DependencyContext struct {
@@ -980,6 +1014,17 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Header, l2GenesisBlockHa
 
 	l1StartTime := l1StartBlock.Time
 
+	var l2BlobConfig *rollup.L2BlobConfig
+	if d.L2GenesisBlobTimeOffset != nil {
+		l2BlobConfig = &rollup.L2BlobConfig{
+			L2BlobTime: d.L2BlobTime(l1StartTime),
+		}
+	}
+	var inboxContractConfig *rollup.InboxContractConfig
+	if d.UseInboxContract {
+		inboxContractConfig = &rollup.InboxContractConfig{UseInboxContract: true}
+	}
+
 	return &rollup.Config{
 		Genesis: rollup.Genesis{
 			L1: eth.BlockID{
@@ -1017,6 +1062,8 @@ func (d *DeployConfig) RollupConfig(l1StartBlock *types.Header, l2GenesisBlockHa
 		InteropTime:             d.InteropTime(l1StartTime),
 		ProtocolVersionsAddress: d.ProtocolVersionsProxy,
 		AltDAConfig:             altDA,
+		L2BlobConfig:            l2BlobConfig,
+		InboxContractConfig:     inboxContractConfig,
 	}, nil
 }
 

--- a/op-chain-ops/genesis/config.go
+++ b/op-chain-ops/genesis/config.go
@@ -481,14 +481,7 @@ func (d *UpgradeScheduleDeployConfig) InteropTime(genesisTime uint64) *uint64 {
 }
 
 func (d *UpgradeScheduleDeployConfig) L2BlobTime(genesisTime uint64) *uint64 {
-	if d.L2GenesisBlobTimeOffset == nil {
-		return nil
-	}
-	v := uint64(0)
-	if offset := *d.L2GenesisBlobTimeOffset; offset > 0 {
-		v = genesisTime + uint64(offset)
-	}
-	return &v
+	return offsetToUpgradeTime(d.L2GenesisBlobTimeOffset, genesisTime)
 }
 
 func (d *UpgradeScheduleDeployConfig) AllocMode(genesisTime uint64) L2AllocsMode {

--- a/op-chain-ops/genesis/genesis.go
+++ b/op-chain-ops/genesis/genesis.go
@@ -41,6 +41,10 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 	}
 
 	l1StartTime := l1StartHeader.Time
+	var soulGasTokenBlock *uint64
+	if config.UseSoulGasToken {
+		soulGasTokenBlock = u64ptr(config.SoulGasTokenBlock)
+	}
 
 	optimismChainConfig := params.ChainConfig{
 		ChainID:                       new(big.Int).SetUint64(config.L2ChainID),
@@ -72,10 +76,13 @@ func NewL2Genesis(config *DeployConfig, l1StartHeader *types.Header) (*core.Gene
 		GraniteTime:                   config.GraniteTime(l1StartTime),
 		HoloceneTime:                  config.HoloceneTime(l1StartTime),
 		InteropTime:                   config.InteropTime(l1StartTime),
+		L2BlobTime:                    config.L2BlobTime(l1StartTime),
 		Optimism: &params.OptimismConfig{
 			EIP1559Denominator:       eip1559Denom,
 			EIP1559Elasticity:        eip1559Elasticity,
 			EIP1559DenominatorCanyon: &eip1559DenomCanyon,
+			IsSoulBackedByNative:     config.IsSoulBackedByNative,
+			SoulGasTokenBlock:        soulGasTokenBlock,
 		},
 	}
 

--- a/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
+++ b/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
@@ -11,8 +11,8 @@ import (
 var (
 	// baseFeePadFactor = 50% as a divisor
 	baseFeePadFactor = big.NewInt(2)
-	// tipMulFactor = 20 as a multiplier
-	tipMulFactor = big.NewInt(20)
+	// tipMulFactor = 5 as a multiplier
+	tipMulFactor = big.NewInt(5)
 	// dummyBlobFee is a dummy value for the blob fee. Since this gas estimator will never
 	// post blobs, it's just set to 1.
 	dummyBlobFee = big.NewInt(1)

--- a/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
+++ b/op-deployer/pkg/deployer/broadcaster/gas_estimator.go
@@ -16,6 +16,11 @@ var (
 	// dummyBlobFee is a dummy value for the blob fee. Since this gas estimator will never
 	// post blobs, it's just set to 1.
 	dummyBlobFee = big.NewInt(1)
+
+	// maxTip is the maximum tip that can be suggested by this estimator.
+	maxTip = big.NewInt(50 * 1e9)
+	// minTip is the minimum tip that can be suggested by this estimator.
+	minTip = big.NewInt(1 * 1e9)
 )
 
 // DeployerGasPriceEstimator is a custom gas price estimator for use with op-deployer.
@@ -34,5 +39,13 @@ func DeployerGasPriceEstimator(ctx context.Context, client txmgr.ETHBackend) (*b
 	baseFeePad := new(big.Int).Div(chainHead.BaseFee, baseFeePadFactor)
 	paddedBaseFee := new(big.Int).Add(chainHead.BaseFee, baseFeePad)
 	paddedTip := new(big.Int).Mul(tip, tipMulFactor)
+
+	if paddedTip.Cmp(minTip) < 0 {
+		paddedTip.Set(minTip)
+	}
+
+	if paddedTip.Cmp(maxTip) > 0 {
+		paddedTip.Set(maxTip)
+	}
 	return paddedTip, paddedBaseFee, dummyBlobFee, nil
 }

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -139,6 +139,32 @@ type Config struct {
 
 	// AltDAConfig. We are in the process of migrating to the AltDAConfig from these legacy top level values
 	AltDAConfig *AltDAConfig `json:"alt_da,omitempty"`
+
+	L2BlobConfig        *L2BlobConfig        `json:"l2_blob_config,omitempty"`
+	InboxContractConfig *InboxContractConfig `json:"inbox_contract_config,omitempty"`
+}
+
+type L2BlobConfig struct {
+	L2BlobTime *uint64 `json:"l2BlobTime,omitempty"`
+}
+
+type InboxContractConfig struct {
+	UseInboxContract bool `json:"use_inbox_contract,omitempty"`
+}
+
+// IsL2Blob returns whether l2 blob is enabled
+func (cfg *Config) IsL2Blob(parentTime uint64) bool {
+	return cfg.IsL2BlobTimeSet() && *cfg.L2BlobConfig.L2BlobTime <= parentTime
+}
+
+// UseInboxContract returns whether inbox contract is enabled
+func (cfg *Config) UseInboxContract() bool {
+	return cfg.InboxContractConfig != nil && cfg.InboxContractConfig.UseInboxContract
+}
+
+// IsL2BlobTimeSet returns whether l2 blob activation time is set
+func (cfg *Config) IsL2BlobTimeSet() bool {
+	return cfg.L2BlobConfig != nil && cfg.L2BlobConfig.L2BlobTime != nil
 }
 
 // ValidateL1Config checks L1 config variables for errors.
@@ -647,6 +673,11 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		networkL1 = "unknown L1"
 	}
 
+	var l2BlobTime *uint64
+	if c.L2BlobConfig != nil {
+		l2BlobTime = c.L2BlobConfig.L2BlobTime
+	}
+
 	log.Info("Rollup Config", "l2_chain_id", c.L2ChainID, "l2_network", networkL2, "l1_chain_id", c.L1ChainID,
 		"l1_network", networkL1, "l2_start_time", c.Genesis.L2Time, "l2_block_hash", c.Genesis.L2.Hash.String(),
 		"l2_block_number", c.Genesis.L2.Number, "l1_block_hash", c.Genesis.L1.Hash.String(),
@@ -659,6 +690,8 @@ func (c *Config) LogDescription(log log.Logger, l2Chains map[string]string) {
 		"holocene_time", fmtForkTimeOrUnset(c.HoloceneTime),
 		"interop_time", fmtForkTimeOrUnset(c.InteropTime),
 		"alt_da", c.AltDAConfig != nil,
+		"l2_blob_config", fmtForkTimeOrUnset(l2BlobTime),
+		"use_inbox_contract", c.UseInboxContract(),
 	)
 }
 

--- a/packages/contracts-bedrock/scripts/Artifacts.s.sol
+++ b/packages/contracts-bedrock/scripts/Artifacts.s.sol
@@ -109,6 +109,8 @@ abstract contract Artifacts {
         bytes32 digest = keccak256(bytes(_name));
         if (digest == keccak256(bytes("L2CrossDomainMessenger"))) {
             return payable(Predeploys.L2_CROSS_DOMAIN_MESSENGER);
+        } else if (digest == keccak256(bytes("SoulGasToken"))) {
+            return payable(Predeploys.SOUL_GAS_TOKEN);
         } else if (digest == keccak256(bytes("L2ToL1MessagePasser"))) {
             return payable(Predeploys.L2_TO_L1_MESSAGE_PASSER);
         } else if (digest == keccak256(bytes("L2StandardBridge"))) {

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -32,6 +32,8 @@ import { IL2CrossDomainMessenger } from "src/L2/interfaces/IL2CrossDomainMesseng
 import { IGasPriceOracle } from "src/L2/interfaces/IGasPriceOracle.sol";
 import { IL1Block } from "src/L2/interfaces/IL1Block.sol";
 
+import { SoulGasToken } from "src/L2/SoulGasToken.sol";
+
 struct L1Dependencies {
     address payable l1CrossDomainMessengerProxy;
     address payable l1StandardBridgeProxy;
@@ -268,6 +270,7 @@ contract L2Genesis is Deployer {
         // 1B,1C,1D,1E,1F: not used.
         setSchemaRegistry(); // 20
         setEAS(); // 21
+        if (cfg.useSoulGasToken()) setSoulGasToken(); // 800
         setGovernanceToken(); // 42: OP (not behind a proxy)
         if (cfg.useInterop()) {
             setCrossL2Inbox(); // 22
@@ -294,6 +297,44 @@ contract L2Genesis is Deployer {
 
     function setL2ToL1MessagePasser() public {
         _setImplementationCode(Predeploys.L2_TO_L1_MESSAGE_PASSER);
+    }
+
+    /// @notice This predeploy is following the safety invariant #2.
+    function setSoulGasToken() public {
+        address impl = Predeploys.predeployToCodeNamespace(Predeploys.SOUL_GAS_TOKEN);
+        console.log(
+            "Setting %s implementation at: %s, isSoulBackedByNative:%d",
+            "SoulGasToken",
+            impl,
+            cfg.isSoulBackedByNative()
+        );
+        SoulGasToken token;
+        if (cfg.isSoulBackedByNative()) {
+            token = new SoulGasToken({ _isBackedByNative: true });
+        } else {
+            token = new SoulGasToken({ _isBackedByNative: false });
+        }
+        vm.etch(impl, address(token).code);
+
+        /// Reset so its not included state dump
+        vm.etch(address(token), "");
+        vm.resetNonce(address(token));
+
+        if (cfg.isSoulBackedByNative()) {
+            SoulGasToken(impl).initialize({ _name: "", _symbol: "", _owner: cfg.proxyAdminOwner() });
+            SoulGasToken(Predeploys.SOUL_GAS_TOKEN).initialize({
+                _name: "SoulQKC",
+                _symbol: "SoulQKC",
+                _owner: cfg.proxyAdminOwner()
+            });
+        } else {
+            SoulGasToken(impl).initialize({ _name: "", _symbol: "", _owner: cfg.proxyAdminOwner() });
+            SoulGasToken(Predeploys.SOUL_GAS_TOKEN).initialize({
+                _name: "SoulQKC",
+                _symbol: "SoulQKC",
+                _owner: cfg.proxyAdminOwner()
+            });
+        }
     }
 
     /// @notice This predeploy is following the safety invariant #1.

--- a/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
+++ b/packages/contracts-bedrock/scripts/checks/check-semver-diff.sh
@@ -16,13 +16,13 @@ temp_dir=$(mktemp -d)
 trap 'rm -rf "$temp_dir"' EXIT
 
 # Exit early if semver-lock.json has not changed.
-if ! { git diff origin/develop...HEAD --name-only; git diff --name-only; git diff --cached --name-only; } | grep -q "$SEMVER_LOCK"; then
+if ! { git diff origin/op-es...HEAD --name-only; git diff --name-only; git diff --cached --name-only; } | grep -q "$SEMVER_LOCK"; then
     echo "No changes detected in semver-lock.json"
     exit 0
 fi
 
 # Get the upstream semver-lock.json.
-git show origin/develop:packages/contracts-bedrock/snapshots/semver-lock.json > "$temp_dir/upstream_semver_lock.json"
+git show origin/op-es:packages/contracts-bedrock/snapshots/semver-lock.json > "$temp_dir/upstream_semver_lock.json"
 
 # Copy the local semver-lock.json.
 cp "$SEMVER_LOCK" "$temp_dir/local_semver_lock.json"
@@ -56,7 +56,7 @@ for contract in $changed_contracts; do
     # Extract the old and new source files.
     old_source_file="$temp_dir/old_${contract##*/}"
     new_source_file="$temp_dir/new_${contract##*/}"
-    git show origin/develop:packages/contracts-bedrock/"$contract" > "$old_source_file" 2>/dev/null || true
+    git show origin/op-es:packages/contracts-bedrock/"$contract" > "$old_source_file" 2>/dev/null || true
     cp "$contract" "$new_source_file"
 
     # Extract the old and new versions.

--- a/packages/contracts-bedrock/scripts/checks/interfaces/main.go
+++ b/packages/contracts-bedrock/scripts/checks/interfaces/main.go
@@ -29,6 +29,7 @@ var excludeContracts = []string{
 	// TODO: Interfaces that need to be fixed
 	"IInitializable", "IOptimismMintableERC20", "ILegacyMintableERC20",
 	"KontrolCheatsBase", "ISystemConfigInterop", "IResolvedDelegateProxy",
+	"IERC20Upgradeable", "ISoulGasToken", "IStorageSetter",
 }
 
 type ContractDefinition struct {

--- a/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/DeployConfig.s.sol
@@ -91,6 +91,8 @@ contract DeployConfig is Script {
     address public customGasTokenAddress;
 
     bool public useInterop;
+    bool public useSoulGasToken;
+    bool public isSoulBackedByNative;
 
     function read(string memory _path) public {
         console.log("DeployConfig: reading file %s", _path);
@@ -177,6 +179,8 @@ contract DeployConfig is Script {
         customGasTokenAddress = _readOr(_json, "$.customGasTokenAddress", address(0));
 
         useInterop = _readOr(_json, "$.useInterop", false);
+        useSoulGasToken = _readOr(_json, "$.useSoulGasToken", false);
+        isSoulBackedByNative = _readOr(_json, "$.isSoulBackedByNative", false);
     }
 
     function fork() public view returns (Fork fork_) {
@@ -234,6 +238,16 @@ contract DeployConfig is Script {
     /// @notice Allow the `useInterop` config to be overridden in testing environments
     function setUseInterop(bool _useInterop) public {
         useInterop = _useInterop;
+    }
+
+    /// @notice Allow the `useSoulGasToken` config to be overridden in testing environments
+    function setUseSoulGasToken(bool _useSoulGasToken) public {
+        useSoulGasToken = _useSoulGasToken;
+    }
+
+    /// @notice Allow the `isSoulBackedByNative` config to be overridden in testing environments
+    function setIsSoulBackedByNative(bool _isSoulBackedByNative) public {
+        isSoulBackedByNative = _isSoulBackedByNative;
     }
 
     /// @notice Allow the `fundDevAccounts` config to be overridden.

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeAnchorStateRegistry.s.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Forge
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Libraries
+import { GameType, Hash, OutputRoot } from "src/dispute/lib/Types.sol";
+// Contracts
+import { IStorageSetter } from "src/universal/interfaces/IStorageSetter.sol";
+// Interfaces
+import { IAnchorStateRegistry } from "src/dispute/interfaces/IAnchorStateRegistry.sol";
+import { IDisputeGameFactory } from "src/dispute/interfaces/IDisputeGameFactory.sol";
+import { IProxyAdmin } from "src/universal/interfaces/IProxyAdmin.sol";
+import { ISuperchainConfig } from "src/L1/interfaces/ISuperchainConfig.sol";
+
+/// @title UpgradeAnchorStateRegistry
+contract UpgradeAnchorStateRegistry is Script {
+    function run(
+        address _disputeGameFactoryProxy,
+        address _opChainProxyAdmin,
+        address _anchorStateRegistryProxy,
+        address _superchainConfig,
+        address _storageSetter,
+        uint32 _type,
+        uint256 _l2BlockNumber,
+        bytes32 _outputRoot
+    )
+        public
+    {
+        console.log("_disputeGameFactoryProxy: %s", _disputeGameFactoryProxy);
+        console.log("_opChainProxyAdmin: %s", _opChainProxyAdmin);
+        console.log("_anchorStateRegistryProxy: %s", _anchorStateRegistryProxy);
+        console.log("_superchainConfig: %s", _superchainConfig);
+        console.log("_storageSetter: %s", _storageSetter);
+        console.log("_type: %s", _type);
+        console.log("_l2BlockNumber: %s", _l2BlockNumber);
+        console.log("_outputRoot: %s", bytes32ToHex(_outputRoot));
+
+        vm.startBroadcast();
+        upgradeAnchorStateRegistryImpl(
+            IDisputeGameFactory(_disputeGameFactoryProxy),
+            IProxyAdmin(_opChainProxyAdmin),
+            IAnchorStateRegistry(_anchorStateRegistryProxy),
+            ISuperchainConfig(_superchainConfig),
+            _storageSetter,
+            GameType.wrap(_type),
+            _l2BlockNumber,
+            Hash.wrap(_outputRoot)
+        );
+        vm.stopBroadcast();
+        checkOutput(
+            IAnchorStateRegistry(_anchorStateRegistryProxy),
+            GameType.wrap(_type),
+            _l2BlockNumber,
+            Hash.wrap(_outputRoot)
+        );
+    }
+
+    function upgradeAnchorStateRegistryImpl(
+        IDisputeGameFactory _disputeGameFactoryProxy,
+        IProxyAdmin _opChainProxyAdmin,
+        IAnchorStateRegistry _anchorStateRegistryProxy,
+        ISuperchainConfig _superchainConfig,
+        address _storageSetter,
+        GameType _type,
+        uint256 _l2BlockNumber,
+        Hash _outputRoot
+    )
+        internal
+    {
+        address anchorStateRegistryImpl = DeployUtils.create1({
+            _name: "AnchorStateRegistry",
+            _args: DeployUtils.encodeConstructor(
+                abi.encodeCall(IAnchorStateRegistry.__constructor__, (_disputeGameFactoryProxy))
+            )
+        });
+
+        if (_storageSetter == address(0)) {
+            _storageSetter = DeployUtils.create1({
+                _name: "StorageSetter",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IStorageSetter.__constructor__, ()))
+            });
+        }
+
+        bytes memory data;
+        data = encodeStorageSetterZeroOutInitializedSlot();
+        upgradeAndCall(_opChainProxyAdmin, address(_anchorStateRegistryProxy), _storageSetter, data);
+        data = encodeAnchorStateRegistryInitializer(_type, _l2BlockNumber, _outputRoot, _superchainConfig);
+        upgradeAndCall(_opChainProxyAdmin, address(_anchorStateRegistryProxy), anchorStateRegistryImpl, data);
+    }
+
+    function encodeStorageSetterZeroOutInitializedSlot() internal pure returns (bytes memory) {
+        return abi.encodeCall(IStorageSetter.setBytes32, (0, 0));
+    }
+
+    function encodeAnchorStateRegistryInitializer(
+        GameType _type,
+        uint256 _l2BlockNumber,
+        Hash _outputRoot,
+        ISuperchainConfig _superchainConfig
+    )
+        internal
+        view
+        virtual
+        returns (bytes memory)
+    {
+        IAnchorStateRegistry.StartingAnchorRoot[] memory startingAnchorRoots =
+            new IAnchorStateRegistry.StartingAnchorRoot[](1);
+        startingAnchorRoots[0] = IAnchorStateRegistry.StartingAnchorRoot({
+            gameType: _type,
+            outputRoot: OutputRoot({ root: _outputRoot, l2BlockNumber: _l2BlockNumber })
+        });
+        return abi.encodeCall(IAnchorStateRegistry.initialize, (startingAnchorRoots, _superchainConfig));
+    }
+
+    /// @notice Makes an external call to the target to initialize the proxy with the specified data.
+    /// First performs safety checks to ensure the target, implementation, and proxy admin are valid.
+    function upgradeAndCall(
+        IProxyAdmin _proxyAdmin,
+        address _target,
+        address _implementation,
+        bytes memory _data
+    )
+        internal
+    {
+        DeployUtils.assertValidContractAddress(address(_proxyAdmin));
+        DeployUtils.assertValidContractAddress(_target);
+        DeployUtils.assertValidContractAddress(_implementation);
+
+        _proxyAdmin.upgradeAndCall(payable(address(_target)), _implementation, _data);
+    }
+
+    function checkOutput(
+        IAnchorStateRegistry _anchorStateRegistryProxy,
+        GameType _type,
+        uint256 _l2BlockNumber,
+        Hash _outputRoot
+    )
+        public
+        view
+    {
+        (Hash root, uint256 l2BlockNumber) = IAnchorStateRegistry(_anchorStateRegistryProxy).anchors(_type);
+        require(Hash.unwrap(root) == Hash.unwrap(_outputRoot), "UpgradeAnchorStateRegistryOutput: root mismatch");
+        require(l2BlockNumber == _l2BlockNumber, "UpgradeAnchorStateRegistryOutput: l2BlockNumber mismatch");
+    }
+
+    function bytes32ToHex(bytes32 _data) internal pure returns (string memory) {
+        bytes memory result = new bytes(64);
+        for (uint256 i = 0; i < 32; i++) {
+            uint8 byteValue = uint8(_data[i]);
+            result[i * 2] = toHexChar(byteValue / 16);
+            result[i * 2 + 1] = toHexChar(byteValue % 16);
+        }
+        return string(result);
+    }
+
+    function toHexChar(uint8 _b) internal pure returns (bytes1) {
+        return _b < 10 ? bytes1(_b + 0x30) : bytes1(_b + 0x57);
+    }
+}

--- a/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/UpgradeSoulGasToken.s.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+// Forge
+import { Script } from "forge-std/Script.sol";
+
+// Scripts
+import { DeployUtils } from "scripts/libraries/DeployUtils.sol";
+
+// Contracts
+import { StorageSetter } from "src/universal/StorageSetter.sol";
+
+// Interfaces
+import { IProxyAdmin } from "src/universal/interfaces/IProxyAdmin.sol";
+import { IStorageSetter } from "src/universal/interfaces/IStorageSetter.sol";
+import { ISoulGasToken } from "src/L2/interfaces/ISoulGasToken.sol";
+
+/// @title UpgradeSoulGasToken
+contract UpgradeSoulGasToken is Script {
+    IProxyAdmin constant proxyAdmin = IProxyAdmin(0x4200000000000000000000000000000000000018);
+    ISoulGasToken constant soulGasToken = ISoulGasToken(0x4200000000000000000000000000000000000800);
+
+    function run(address _storageSetter) public {
+        address sgtOwner = getSGTOwner();
+        preCheck();
+
+        vm.startBroadcast();
+        upgradeSoulGasTokenImpl(_storageSetter);
+        vm.stopBroadcast();
+        postCheck(sgtOwner);
+    }
+
+    function upgradeSoulGasTokenImpl(address _storageSetter) internal {
+        if (_storageSetter == address(0)) {
+            _storageSetter = DeployUtils.create1({
+                _name: "StorageSetter",
+                _args: DeployUtils.encodeConstructor(abi.encodeCall(IStorageSetter.__constructor__, ()))
+            });
+        }
+
+        address sgtOwner = ISoulGasToken(soulGasToken).owner();
+
+        address impl = proxyAdmin.getProxyImplementation(address(soulGasToken));
+
+        bytes memory data;
+        data = encodeStorageSetterZeroOutInitializedSlot();
+        upgradeAndCall(proxyAdmin, address(soulGasToken), _storageSetter, data);
+        data = encodeSoulGasTokenInitializer(sgtOwner);
+        upgradeAndCall(proxyAdmin, address(soulGasToken), impl, data);
+    }
+
+    function encodeStorageSetterZeroOutInitializedSlot() internal pure returns (bytes memory) {
+        return abi.encodeCall(IStorageSetter.setBytes32, (0, 0));
+    }
+
+    function encodeSoulGasTokenInitializer(address _sgtOwner) internal view virtual returns (bytes memory) {
+        return abi.encodeCall(ISoulGasToken.initialize, ("SoulQKC", "SoulQKC", _sgtOwner));
+    }
+
+    /// @notice Makes an external call to the target to initialize the proxy with the specified data.
+    /// First performs safety checks to ensure the target, implementation, and proxy admin are valid.
+    function upgradeAndCall(
+        IProxyAdmin _proxyAdmin,
+        address _target,
+        address _implementation,
+        bytes memory _data
+    )
+        internal
+    {
+        DeployUtils.assertValidContractAddress(address(_proxyAdmin));
+        DeployUtils.assertValidContractAddress(_target);
+        DeployUtils.assertValidContractAddress(_implementation);
+
+        _proxyAdmin.upgradeAndCall(payable(address(_target)), _implementation, _data);
+    }
+
+    function getSGTOwner() public view returns (address) {
+        return soulGasToken.owner();
+    }
+
+    function preCheck() public view {
+        address sgtAdmin = proxyAdmin.getProxyAdmin(payable(address(soulGasToken)));
+        require(sgtAdmin == address(proxyAdmin), "UpgradeSoulGasToken: admin not match");
+    }
+
+    function postCheck(address _sgtOwner) public view {
+        require(
+            keccak256(abi.encodePacked(soulGasToken.name())) == keccak256("SoulQKC"),
+            "UpgradeSoulGasToken: name not match"
+        );
+        require(
+            keccak256(abi.encodePacked(soulGasToken.symbol())) == keccak256("SoulQKC"),
+            "UpgradeSoulGasToken: symbol not match"
+        );
+        require(soulGasToken.owner() == _sgtOwner, "UpgradeSoulGasToken: owner not match");
+    }
+}

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -57,6 +57,25 @@ contract L1Block is ISemver, IGasToken {
     /// @notice The latest L1 blob base fee.
     uint256 public blobBaseFee;
 
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L1Block.HistoryHashesStorage")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _L1BLOCK_HISTORY_HASHES_LOCATION =
+        0xb6e35d777715793a0808adb4ab3d51fc56065457feaf3a18bd958afef33bef00;
+    /// @notice size of historyHashes.
+    uint256 internal constant HISTORY_SIZE = 8192;
+    /// @custom:storage-location erc7201:openzeppelin.storage.L1Block.HistoryHashesStorage
+
+    struct HistoryHashesStorage {
+        /// @notice The 8191 history L1 blockhashes and 1 latest L1 blockhash.
+        bytes32[HISTORY_SIZE] historyHashes;
+    }
+
+    function _getHistoryHashesStorage() private pure returns (HistoryHashesStorage storage $) {
+        assembly {
+            $.slot := _L1BLOCK_HISTORY_HASHES_LOCATION
+        }
+    }
+
     /// @custom:semver 1.5.1-beta.3
     function version() public pure virtual returns (string memory) {
         return "1.5.1-beta.3";
@@ -166,6 +185,36 @@ contract L1Block is ISemver, IGasToken {
             sstore(hash.slot, calldataload(100)) // bytes32
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
+
+        HistoryHashesStorage storage $ = _getHistoryHashesStorage();
+        $.historyHashes[number % HISTORY_SIZE] = hash;
+    }
+
+    /// @notice Returns the L1 block hash at the requested L1 blocknumber.
+    /// Only the most recent 8191 L1 block hashes are available, excluding the current one.
+    /// @param _historyNumber         L1 blocknumber.
+    function blockHash(uint256 _historyNumber) external view returns (bytes32) {
+        // translated from
+        // [opBlockhash](https://github.com/ethereum/go-ethereum/blob/e31709db6570e302557a9bccd681034ea0dcc246/core/vm/instructions.go#L434)
+        // with 256 => HISTORY_SIZE-1
+        uint256 lower;
+        uint256 upper = number;
+        if (upper < HISTORY_SIZE) {
+            lower = 0;
+        } else {
+            lower = upper - HISTORY_SIZE + 1;
+        }
+        if (_historyNumber >= lower && _historyNumber < upper) {
+            HistoryHashesStorage storage $ = _getHistoryHashesStorage();
+            return $.historyHashes[_historyNumber % HISTORY_SIZE];
+        } else {
+            return bytes32(0);
+        }
+    }
+
+    /// @notice Returns the size of history hashes.
+    function historySize() external pure returns (uint256) {
+        return HISTORY_SIZE;
     }
 
     /// @notice Sets the gas paying token for the L2 system. Can only be called by the special

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { Constants } from "src/libraries/Constants.sol";
+
+/// @title SoulGasToken
+/// @notice The SoulGasToken is a soul-bounded ERC20 contract which can be used to pay gas on L2.
+///         It has 2 modes:
+///             1. when IS_BACKED_BY_NATIVE(or in other words: SoulQKC mode), the token can be minted by
+///                anyone depositing native token into the contract.
+///             2. when !IS_BACKED_BY_NATIVE(or in other words: SoulETH mode), the token can only be
+///                minted by whitelist minters specified by contract owner.
+contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
+    /// @custom:storage-location erc7201:openzeppelin.storage.SoulGasToken
+    struct SoulGasTokenStorage {
+        // minters are whitelist EOAs, only used when !IS_BACKED_BY_NATIVE
+        mapping(address => bool) minters;
+        // burners are whitelist EOAs to burn/withdraw SoulGasToken
+        mapping(address => bool) burners;
+        // allowSgtValue are whitelist contracts to consume sgt as msg.value
+        // when IS_BACKED_BY_NATIVE
+        mapping(address => bool) allowSgtValue;
+    }
+
+    /// @notice Emitted when sgt as msg.value is enabled for a contract.
+    /// @param from     Address of the contract for which sgt as msg.value is enabled.
+    event AllowSgtValue(address indexed from);
+    /// @notice Emitted when sgt as msg.value is disabled for a contract.
+    /// @param from     Address of the contract for which sgt as msg.value is disabled.
+    event DisallowSgtValue(address indexed from);
+
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.SoulGasToken")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant _SOULGASTOKEN_STORAGE_LOCATION =
+        0x135c38e215d95c59dcdd8fe622dccc30d04cacb8c88c332e4e7441bac172dd00;
+
+    bool internal immutable IS_BACKED_BY_NATIVE;
+
+    function _getSoulGasTokenStorage() private pure returns (SoulGasTokenStorage storage $) {
+        assembly {
+            $.slot := _SOULGASTOKEN_STORAGE_LOCATION
+        }
+    }
+
+    constructor(bool _isBackedByNative) {
+        IS_BACKED_BY_NATIVE = _isBackedByNative;
+        initialize("", "", msg.sender);
+    }
+
+    /// @notice Initializer.
+    function initialize(string memory _name, string memory _symbol, address _owner) public initializer {
+        __Ownable_init();
+        transferOwnership(_owner);
+
+        // initialize the inherited ERC20Upgradeable
+        __ERC20_init(_name, _symbol);
+    }
+
+    /// @notice deposit can be called by anyone to deposit native token for SoulGasToken when
+    /// IS_BACKED_BY_NATIVE.
+    function deposit() external payable {
+        require(IS_BACKED_BY_NATIVE, "SGT: deposit should only be called when IS_BACKED_BY_NATIVE");
+
+        _mint(_msgSender(), msg.value);
+    }
+
+    /// @notice batchDepositFor can be called by anyone to deposit native token for SoulGasToken in batch when
+    /// IS_BACKED_BY_NATIVE.
+    function batchDepositFor(address[] calldata _accounts, uint256[] calldata _values) external payable {
+        require(_accounts.length == _values.length, "SGT: invalid arguments");
+
+        require(IS_BACKED_BY_NATIVE, "SGT: batchDepositFor should only be called when IS_BACKED_BY_NATIVE");
+
+        uint256 totalValue = 0;
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _mint(_accounts[i], _values[i]);
+            totalValue += _values[i];
+        }
+        require(msg.value == totalValue, "SGT: unexpected msg.value");
+    }
+
+    /// @notice batchDepositForAll is similar to batchDepositFor, but the value is the same for all accounts.
+    function batchDepositForAll(address[] calldata _accounts, uint256 _value) external payable {
+        require(IS_BACKED_BY_NATIVE, "SGT: batchDepositForAll should only be called when IS_BACKED_BY_NATIVE");
+
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _mint(_accounts[i], _value);
+        }
+        require(msg.value == _value * _accounts.length, "SGT: unexpected msg.value");
+    }
+
+    /// @notice withdrawFrom is called by the burner to burn SoulGasToken and return the native token when
+    /// IS_BACKED_BY_NATIVE.
+    function withdrawFrom(address _account, uint256 _value) external {
+        require(IS_BACKED_BY_NATIVE, "SGT: withdrawFrom should only be called when IS_BACKED_BY_NATIVE");
+
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        require($.burners[_msgSender()], "SGT: not the burner");
+
+        _burn(_account, _value);
+        payable(_msgSender()).transfer(_value);
+    }
+
+    /// @notice batchWithdrawFrom is the batch version of withdrawFrom.
+    function batchWithdrawFrom(address[] calldata _accounts, uint256[] calldata _values) external {
+        require(_accounts.length == _values.length, "SGT: invalid arguments");
+
+        require(IS_BACKED_BY_NATIVE, "SGT: batchWithdrawFrom should only be called when IS_BACKED_BY_NATIVE");
+
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        require($.burners[_msgSender()], "SGT: not the burner");
+
+        uint256 totalValue = 0;
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _burn(_accounts[i], _values[i]);
+            totalValue += _values[i];
+        }
+
+        payable(_msgSender()).transfer(totalValue);
+    }
+
+    /// @notice batchMint is called:
+    ///                        1. by EOA minters to mint SoulGasToken in batch when !IS_BACKED_BY_NATIVE.
+    ///                        2. by DEPOSITOR_ACCOUNT to refund SoulGasToken
+    function batchMint(address[] calldata _accounts, uint256[] calldata _values) external {
+        require(_accounts.length == _values.length, "SGT: invalid arguments");
+
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        require(_msgSender() == Constants.DEPOSITOR_ACCOUNT || $.minters[_msgSender()], "SGT: not a minter");
+
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _mint(_accounts[i], _values[i]);
+        }
+    }
+
+    /// @notice addMinters is called by the owner to add minters when !IS_BACKED_BY_NATIVE.
+    function addMinters(address[] calldata _minters) external onlyOwner {
+        require(!IS_BACKED_BY_NATIVE, "SGT: addMinters should only be called when !IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < _minters.length; i++) {
+            $.minters[_minters[i]] = true;
+        }
+    }
+
+    /// @notice delMinters is called by the owner to delete minters when !IS_BACKED_BY_NATIVE.
+    function delMinters(address[] calldata _minters) external onlyOwner {
+        require(!IS_BACKED_BY_NATIVE, "SGT: delMinters should only be called when !IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < _minters.length; i++) {
+            delete $.minters[_minters[i]];
+        }
+    }
+
+    /// @notice addBurners is called by the owner to add burners.
+    function addBurners(address[] calldata _burners) external onlyOwner {
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < _burners.length; i++) {
+            $.burners[_burners[i]] = true;
+        }
+    }
+
+    /// @notice delBurners is called by the owner to delete burners.
+    function delBurners(address[] calldata _burners) external onlyOwner {
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < _burners.length; i++) {
+            delete $.burners[_burners[i]];
+        }
+    }
+
+    /// @notice allowSgtValue is called by the owner to enable whitelist contracts to consume sgt as msg.value
+    function allowSgtValue(address[] calldata _contracts) external onlyOwner {
+        require(IS_BACKED_BY_NATIVE, "SGT: allowSgtValue should only be called when IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < _contracts.length; i++) {
+            $.allowSgtValue[_contracts[i]] = true;
+            emit AllowSgtValue(_contracts[i]);
+        }
+    }
+
+    /// @notice allowSgtValue is called by the owner to disable whitelist contracts to consume sgt as msg.value
+    function disallowSgtValue(address[] calldata _contracts) external onlyOwner {
+        require(IS_BACKED_BY_NATIVE, "SGT: disallowSgtValue should only be called when IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        uint256 i;
+        for (i = 0; i < _contracts.length; i++) {
+            $.allowSgtValue[_contracts[i]] = false;
+            emit DisallowSgtValue(_contracts[i]);
+        }
+    }
+
+    /// @notice chargeFromOrigin is called when IS_BACKED_BY_NATIVE to charge for native balance
+    ///         from tx.origin if caller is whitelisted.
+    function chargeFromOrigin(uint256 _amount) external returns (uint256 amountCharged_) {
+        require(IS_BACKED_BY_NATIVE, "SGT: chargeFromOrigin should only be called when IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        require($.allowSgtValue[_msgSender()], "SGT: caller is not whitelisted");
+        uint256 balance = balanceOf(tx.origin);
+        if (balance == 0) {
+            amountCharged_ = 0;
+            return amountCharged_;
+        }
+        if (balance >= _amount) {
+            amountCharged_ = _amount;
+        } else {
+            amountCharged_ = balance;
+        }
+        _burn(tx.origin, amountCharged_);
+        payable(_msgSender()).transfer(amountCharged_);
+    }
+
+    /// @notice burnFrom is called when !IS_BACKED_BY_NATIVE:
+    ///                             1. by the burner to burn SoulGasToken.
+    ///                             2. by DEPOSITOR_ACCOUNT to burn SoulGasToken.
+    function burnFrom(address _account, uint256 _value) external {
+        require(!IS_BACKED_BY_NATIVE, "SGT: burnFrom should only be called when !IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        require(_msgSender() == Constants.DEPOSITOR_ACCOUNT || $.burners[_msgSender()], "SGT: not the burner");
+        _burn(_account, _value);
+    }
+
+    /// @notice batchBurnFrom is the batch version of burnFrom.
+    function batchBurnFrom(address[] calldata _accounts, uint256[] calldata _values) external {
+        require(_accounts.length == _values.length, "SGT: invalid arguments");
+        require(!IS_BACKED_BY_NATIVE, "SGT: batchBurnFrom should only be called when !IS_BACKED_BY_NATIVE");
+        SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
+        require(_msgSender() == Constants.DEPOSITOR_ACCOUNT || $.burners[_msgSender()], "SGT: not the burner");
+
+        for (uint256 i = 0; i < _accounts.length; i++) {
+            _burn(_accounts[i], _values[i]);
+        }
+    }
+
+    /// @notice transferFrom is disabled for SoulGasToken.
+    function transfer(address, uint256) public virtual override returns (bool) {
+        revert("SGT: transfer is disabled for SoulGasToken");
+    }
+
+    /// @notice transferFrom is disabled for SoulGasToken.
+    function transferFrom(address, address, uint256) public virtual override returns (bool) {
+        revert("SGT: transferFrom is disabled for SoulGasToken");
+    }
+
+    /// @notice approve is disabled for SoulGasToken.
+    function approve(address, uint256) public virtual override returns (bool) {
+        revert("SGT: approve is disabled for SoulGasToken");
+    }
+
+    /// @notice Returns whether SoulGasToken is backed by native token.
+    function isBackedByNative() external view returns (bool) {
+        return IS_BACKED_BY_NATIVE;
+    }
+}

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -123,6 +123,8 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
     /// @notice batchMint is called:
     ///                        1. by EOA minters to mint SoulGasToken in batch when !IS_BACKED_BY_NATIVE.
     function batchMint(address[] calldata _accounts, uint256[] calldata _values) external {
+        // we don't explicitly check !IS_BACKED_BY_NATIVE here, because if IS_BACKED_BY_NATIVE,
+        // there's no way to add a minter.
         require(_accounts.length == _values.length, "SGT: invalid arguments");
 
         SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();

--- a/packages/contracts-bedrock/src/L2/SoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/SoulGasToken.sol
@@ -122,12 +122,11 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
 
     /// @notice batchMint is called:
     ///                        1. by EOA minters to mint SoulGasToken in batch when !IS_BACKED_BY_NATIVE.
-    ///                        2. by DEPOSITOR_ACCOUNT to refund SoulGasToken
     function batchMint(address[] calldata _accounts, uint256[] calldata _values) external {
         require(_accounts.length == _values.length, "SGT: invalid arguments");
 
         SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
-        require(_msgSender() == Constants.DEPOSITOR_ACCOUNT || $.minters[_msgSender()], "SGT: not a minter");
+        require($.minters[_msgSender()], "SGT: not a minter");
 
         for (uint256 i = 0; i < _accounts.length; i++) {
             _mint(_accounts[i], _values[i]);
@@ -216,11 +215,10 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
 
     /// @notice burnFrom is called when !IS_BACKED_BY_NATIVE:
     ///                             1. by the burner to burn SoulGasToken.
-    ///                             2. by DEPOSITOR_ACCOUNT to burn SoulGasToken.
     function burnFrom(address _account, uint256 _value) external {
         require(!IS_BACKED_BY_NATIVE, "SGT: burnFrom should only be called when !IS_BACKED_BY_NATIVE");
         SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
-        require(_msgSender() == Constants.DEPOSITOR_ACCOUNT || $.burners[_msgSender()], "SGT: not the burner");
+        require($.burners[_msgSender()], "SGT: not the burner");
         _burn(_account, _value);
     }
 
@@ -229,7 +227,7 @@ contract SoulGasToken is ERC20Upgradeable, OwnableUpgradeable {
         require(_accounts.length == _values.length, "SGT: invalid arguments");
         require(!IS_BACKED_BY_NATIVE, "SGT: batchBurnFrom should only be called when !IS_BACKED_BY_NATIVE");
         SoulGasTokenStorage storage $ = _getSoulGasTokenStorage();
-        require(_msgSender() == Constants.DEPOSITOR_ACCOUNT || $.burners[_msgSender()], "SGT: not the burner");
+        require($.burners[_msgSender()], "SGT: not the burner");
 
         for (uint256 i = 0; i < _accounts.length; i++) {
             _burn(_accounts[i], _values[i]);

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1Block.sol
@@ -38,4 +38,7 @@ interface IL1Block {
     function version() external pure returns (string memory);
 
     function __constructor__() external;
+
+    function historySize() external pure returns (uint256);
+    function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/IL1BlockInterop.sol
@@ -57,4 +57,7 @@ interface IL1BlockInterop {
     function version() external pure returns (string memory);
 
     function __constructor__() external;
+
+    function historySize() external pure returns (uint256);
+    function blockHash(uint256 _historyNumber) external view returns (bytes32);
 }

--- a/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title ISoulGasToken
+/// @notice The interface for the SoulGasToken.
+interface ISoulGasToken {
+    function initialize(string memory _name, string memory _symbol, address _owner) external;
+
+    function __constructor__() external;
+
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function owner() external view returns (address);
+    function admin() external view returns (address);
+}

--- a/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
+++ b/packages/contracts-bedrock/src/L2/interfaces/ISoulGasToken.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
 interface ISoulGasToken {
     function initialize(string memory _name, string memory _symbol, address _owner) external;
 
-    function __constructor__() external;
+    function __constructor__(bool _isBackedByNative) external;
 
     function name() external view returns (string memory);
     function symbol() external view returns (string memory);

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
 //          This excludes the preinstalls (non-protocol contracts).
 library Predeploys {
     /// @notice Number of predeploy-namespace addresses reserved for protocol usage.
-    uint256 internal constant PREDEPLOY_COUNT = 2048;
+    uint256 internal constant PREDEPLOY_COUNT = 4096;
 
     /// @custom:legacy
     /// @notice Address of the LegacyMessagePasser predeploy. Deprecate. Use the updated
@@ -74,6 +74,8 @@ library Predeploys {
     /// @notice Address of the EAS predeploy.
     address internal constant EAS = 0x4200000000000000000000000000000000000021;
 
+    /// @notice Address of the SOUL_GAS_TOKEN predeploy.
+    address internal constant SOUL_GAS_TOKEN = 0x4200000000000000000000000000000000000800;
     /// @notice Address of the GovernanceToken predeploy.
     address internal constant GOVERNANCE_TOKEN = 0x4200000000000000000000000000000000000042;
 
@@ -139,6 +141,7 @@ library Predeploys {
         if (_addr == OPTIMISM_SUPERCHAIN_ERC20_FACTORY) return "OptimismSuperchainERC20Factory";
         if (_addr == OPTIMISM_SUPERCHAIN_ERC20_BEACON) return "OptimismSuperchainERC20Beacon";
         if (_addr == SUPERCHAIN_TOKEN_BRIDGE) return "SuperchainTokenBridge";
+        if (_addr == SOUL_GAS_TOKEN) return "SoulGasToken";
         revert("Predeploys: unnamed predeploy");
     }
 
@@ -159,11 +162,11 @@ library Predeploys {
             || (_useInterop && _addr == SUPERCHAIN_WETH) || (_useInterop && _addr == ETH_LIQUIDITY)
             || (_useInterop && _addr == OPTIMISM_SUPERCHAIN_ERC20_FACTORY)
             || (_useInterop && _addr == OPTIMISM_SUPERCHAIN_ERC20_BEACON)
-            || (_useInterop && _addr == SUPERCHAIN_TOKEN_BRIDGE);
+            || (_useInterop && _addr == SUPERCHAIN_TOKEN_BRIDGE) || _addr == SOUL_GAS_TOKEN;
     }
 
     function isPredeployNamespace(address _addr) internal pure returns (bool) {
-        return uint160(_addr) >> 11 == uint160(0x4200000000000000000000000000000000000000) >> 11;
+        return uint160(_addr) >> 12 == uint160(0x4200000000000000000000000000000000000000) >> 12;
     }
 
     /// @notice Function to compute the expected address of the predeploy implementation

--- a/packages/contracts-bedrock/src/universal/interfaces/IStorageSetter.sol
+++ b/packages/contracts-bedrock/src/universal/interfaces/IStorageSetter.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IStorageSetter {
+    function setBytes32(bytes32, bytes32) external;
+
+    function __constructor__() external;
+}

--- a/packages/contracts-bedrock/test/L2/L1Block.t.sol
+++ b/packages/contracts-bedrock/test/L2/L1Block.t.sol
@@ -163,6 +163,62 @@ contract L1BlockEcotone_Test is L1BlockTest {
         bytes memory expReturn = hex"3cc50b45";
         assertEq(data, expReturn);
     }
+
+    /// @dev Tests that `blockHash` works for block range [n-256, n) where n is the latest
+    /// L1 block number known by the L2 system.
+    function testFuzz_blockHash_succeeds(
+        uint32 baseFeeScalar,
+        uint32 blobBaseFeeScalar,
+        uint64 sequenceNumber,
+        uint64 timestamp,
+        uint64 number,
+        uint256 baseFee,
+        uint256 blobBaseFee,
+        bytes32 hash,
+        bytes32 batcherHash
+    )
+        external
+    {
+        if (number > type(uint64).max - uint64(l1Block.historySize()) - 1) {
+            number = type(uint64).max - uint64(l1Block.historySize()) - 1;
+        }
+        if (uint256(hash) > type(uint256).max - l1Block.historySize() - 1) {
+            hash = bytes32(type(uint256).max - l1Block.historySize() - 1);
+        }
+
+        for (uint256 i = 1; i <= l1Block.historySize() + 1; i++) {
+            bytes memory functionCallDataPacked = Encoding.encodeSetL1BlockValuesEcotone(
+                baseFeeScalar,
+                blobBaseFeeScalar,
+                sequenceNumber,
+                timestamp,
+                number + uint64(i),
+                baseFee,
+                blobBaseFee,
+                bytes32(uint256(hash) + i),
+                batcherHash
+            );
+
+            vm.prank(depositor);
+            (bool success,) = address(l1Block).call(functionCallDataPacked);
+            assertTrue(success, "function call failed");
+
+            assertEq(l1Block.number(), number + uint64(i));
+            assertEq(l1Block.hash(), bytes32(uint256(hash) + i));
+        }
+
+        assertTrue(
+            l1Block.blockHash(number + l1Block.historySize() + 1) == bytes32(0),
+            "should return bytes32(0) for the latest L1 block"
+        );
+        assertTrue(l1Block.blockHash(number + 1) == bytes32(0), "should return bytes32(0) for blocks out of range");
+        for (uint256 i = 2; i <= l1Block.historySize(); i++) {
+            assertTrue(
+                l1Block.blockHash(number + i) == bytes32(uint256(hash) + i),
+                "blockHash's return value should match the value set"
+            );
+        }
+    }
 }
 
 contract L1BlockCustomGasToken_Test is L1BlockTest {

--- a/packages/contracts-bedrock/test/L2/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/L2/L2Genesis.t.sol
@@ -149,7 +149,7 @@ contract L2GenesisTest is Test {
         assertEq(getCodeCount(_path, "Proxy.sol:Proxy"), Predeploys.PREDEPLOY_COUNT - 2);
 
         // 24 proxies have the implementation set if useInterop is true and 17 if useInterop is false
-        assertEq(getPredeployCountWithSlotSet(_path, Constants.PROXY_IMPLEMENTATION_ADDRESS), _useInterop ? 24 : 17);
+        assertEq(getPredeployCountWithSlotSet(_path, Constants.PROXY_IMPLEMENTATION_ADDRESS), _useInterop ? 25 : 18);
 
         // All proxies except 2 have the proxy 1967 admin slot set to the proxy admin
         assertEq(
@@ -178,15 +178,21 @@ contract L2GenesisTest is Test {
 
     /// @notice Tests the number of accounts in the genesis setup
     function _test_allocs_size(string memory _path) internal {
+        vm.mockCall(address(genesis.cfg()), abi.encodeCall(genesis.cfg().useSoulGasToken, ()), abi.encode(true));
+        vm.mockCall(address(genesis.cfg()), abi.encodeCall(genesis.cfg().isSoulBackedByNative, ()), abi.encode(true));
         genesis.cfg().setFundDevAccounts(false);
         genesis.runWithLatestLocal(_dummyL1Deps());
         genesis.writeGenesisAllocs(_path);
 
         uint256 expected = 0;
-        expected += 2048 - 2; // predeploy proxies
-        expected += 21; // predeploy implementations (excl. legacy erc20-style eth and legacy message sender)
+        // predeploy proxies; WETH and GovernanceToken are not behind proxies
+        expected += Predeploys.PREDEPLOY_COUNT - 2;
+        // setPredeployImplementations function in L2Genesis.s.sol sets 20 predeploy implementations (useInterop ==
+        // false)
+        expected += 20;
         expected += 256; // precompiles
-        expected += 13; // preinstalls
+        // setPreinstalls function in SetPreinstalls.s.sol sets 15 preinstalls
+        expected += 15; // preinstalls
         expected += 1; // 4788 deployer account
         // 16 prefunded dev accounts are excluded
         assertEq(expected, getJSONKeyCount(_path), "key count check");

--- a/packages/contracts-bedrock/test/L2/Predeploys.t.sol
+++ b/packages/contracts-bedrock/test/L2/Predeploys.t.sol
@@ -24,7 +24,8 @@ contract PredeploysBaseTest is CommonTest {
     /// @dev Returns true if the predeploy is initializable.
     function _isInitializable(address _addr) internal pure returns (bool) {
         return _addr == Predeploys.L2_CROSS_DOMAIN_MESSENGER || _addr == Predeploys.L2_STANDARD_BRIDGE
-            || _addr == Predeploys.L2_ERC721_BRIDGE || _addr == Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY;
+            || _addr == Predeploys.L2_ERC721_BRIDGE || _addr == Predeploys.OPTIMISM_MINTABLE_ERC20_FACTORY
+            || _addr == Predeploys.SOUL_GAS_TOKEN;
     }
 
     /// @dev Returns true if the predeploy uses immutables.

--- a/packages/contracts-bedrock/test/setup/CommonTest.sol
+++ b/packages/contracts-bedrock/test/setup/CommonTest.sol
@@ -22,6 +22,8 @@ contract CommonTest is Test, Setup, Events {
     bool useLegacyContracts;
     address customGasToken;
     bool useInteropOverride;
+    bool useSoulGasToken;
+    bool isSoulBackedByNative;
 
     function setUp() public virtual override {
         alice = makeAddr("alice");
@@ -44,6 +46,13 @@ contract CommonTest is Test, Setup, Events {
         }
         if (useInteropOverride) {
             deploy.cfg().setUseInterop(true);
+        }
+
+        if (useSoulGasToken) {
+            deploy.cfg().setUseSoulGasToken(true);
+            if (isSoulBackedByNative) {
+                deploy.cfg().setIsSoulBackedByNative(true);
+            }
         }
 
         vm.etch(address(ffi), vm.getDeployedCode("FFIInterface.sol:FFIInterface"));
@@ -149,5 +158,16 @@ contract CommonTest is Test, Setup, Events {
         }
 
         useInteropOverride = true;
+    }
+
+    function enableSoulGasToken() public {
+        // Check if the system has already been deployed, based off of the heuristic that alice and bob have not been
+        // set by the `setUp` function yet.
+        if (!(alice == address(0) && bob == address(0))) {
+            revert("CommonTest: Cannot enable sgt after deployment. Consider overriding `setUp`.");
+        }
+
+        useSoulGasToken = true;
+        isSoulBackedByNative = true;
     }
 }

--- a/packages/contracts-bedrock/test/setup/Setup.sol
+++ b/packages/contracts-bedrock/test/setup/Setup.sol
@@ -49,6 +49,7 @@ import { IWETH98 } from "src/universal/interfaces/IWETH98.sol";
 import { IGovernanceToken } from "src/governance/interfaces/IGovernanceToken.sol";
 import { ILegacyMessagePasser } from "src/legacy/interfaces/ILegacyMessagePasser.sol";
 import { ISuperchainTokenBridge } from "src/L2/interfaces/ISuperchainTokenBridge.sol";
+import { ISoulGasToken } from "src/L2/interfaces/ISoulGasToken.sol";
 
 /// @title Setup
 /// @dev This contact is responsible for setting up the contracts in state. It currently
@@ -111,6 +112,7 @@ contract Setup {
     ISuperchainTokenBridge superchainTokenBridge = ISuperchainTokenBridge(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
     IOptimismSuperchainERC20Factory l2OptimismSuperchainERC20Factory =
         IOptimismSuperchainERC20Factory(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
+    ISoulGasToken soulGasToken = ISoulGasToken(Predeploys.SOUL_GAS_TOKEN);
 
     /// @dev Deploys the Deploy contract without including its bytecode in the bytecode
     ///      of this contract by fetching the bytecode dynamically using `vm.getCode()`.
@@ -237,6 +239,7 @@ contract Setup {
         labelPredeploy(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_FACTORY);
         labelPredeploy(Predeploys.OPTIMISM_SUPERCHAIN_ERC20_BEACON);
         labelPredeploy(Predeploys.SUPERCHAIN_TOKEN_BRIDGE);
+        labelPredeploy(Predeploys.SOUL_GAS_TOKEN);
 
         // L2 Preinstalls
         labelPreinstall(Preinstalls.MultiCall3);

--- a/packages/contracts-bedrock/test/vendor/Initializable.t.sol
+++ b/packages/contracts-bedrock/test/vendor/Initializable.t.sol
@@ -46,6 +46,7 @@ contract Initializer_Test is Bridge_Initializer {
 
     function setUp() public override {
         super.enableAltDA();
+        super.enableSoulGasToken();
         super.enableLegacyContracts();
         super.setUp();
 
@@ -266,6 +267,14 @@ contract Initializer_Test is Bridge_Initializer {
                 name: "L2CrossDomainMessenger",
                 target: address(l2CrossDomainMessenger),
                 initCalldata: abi.encodeCall(l2CrossDomainMessenger.initialize, (l1CrossDomainMessenger))
+            })
+        );
+        // SoulGasToken
+        contracts.push(
+            InitializeableContract({
+                name: "SoulGasToken",
+                target: address(soulGasToken),
+                initCalldata: abi.encodeCall(soulGasToken.initialize, ("SoulGasToken", "SGT", address(0)))
             })
         );
         // L1StandardBridgeImpl


### PR DESCRIPTION
This PR manually re-applies all contracts/op-deployer changes on top of v1.8.0.

The contract changes so far can be inspected by:

```bash
git diff --stat b6b74290b5502f45daae57946f969327cdb2d383 op-es packages/contracts-bedrock
```

The commit `2073f4059bd806af3e8b76b820aa3fa0b42016d0` is chosen as the start point for v1.8.0, the same as Celo.

`forge test` has passed on my local side.