### PR TITLE
Add `ChainOpConfig` to rollup.Config

### DIFF
--- a/op-deployer/pkg/deployer/inspect/genesis.go
+++ b/op-deployer/pkg/deployer/inspect/genesis.go
@@ -79,6 +79,7 @@ func GenesisAndRollup(globalState *state.State, chainID common.Hash) (*core.Gene
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build rollup config: %w", err)
 	}
+	rollupConfig.ChainOpConfig = l2GenesisBuilt.Config.Optimism
 
 	if err := rollupConfig.Check(); err != nil {
 		return nil, nil, fmt.Errorf("generated rollup config does not pass validation: %w", err)

--- a/op-node/rollup/types.go
+++ b/op-node/rollup/types.go
@@ -140,6 +140,12 @@ type Config struct {
 	// AltDAConfig. We are in the process of migrating to the AltDAConfig from these legacy top level values
 	AltDAConfig *AltDAConfig `json:"alt_da,omitempty"`
 
+	// ChainOpConfig is the OptimismConfig of the execution layer ChainConfig.
+	// It is used during safe chain consolidation to translate zero SystemConfig EIP1559
+	// parameters to the protocol values, like the execution layer does.
+	// If missing, it is loaded by the op-node from the embedded superchain config at startup.
+	ChainOpConfig *params.OptimismConfig `json:"chain_op_config,omitempty"`
+
 	L2BlobConfig        *L2BlobConfig        `json:"l2_blob_config,omitempty"`
 	InboxContractConfig *InboxContractConfig `json:"inbox_contract_config,omitempty"`
 }


### PR DESCRIPTION
The latest op-node requires a `ChainOpConfig` field in rollup.Config([FYI](https://github.com/QuarkChain/optimism/blob/1a0a30181369b3295c4fc0b2b981ec4d4c486cad/op-node/node/node.go#L440)), this PR automatically generates it.