### PR TITLE
Exclude SoulGasToken from semgrep rules

### DIFF
--- a/.semgrep/rules/sol-rules.yaml
+++ b/.semgrep/rules/sol-rules.yaml
@@ -330,6 +330,7 @@ rules:
         - packages/contracts-bedrock/src/L2/FeeVault.sol
         - packages/contracts-bedrock/src/L2/OptimismMintableERC721.sol
         - packages/contracts-bedrock/src/L2/OptimismMintableERC721Factory.sol
+        - packages/contracts-bedrock/src/L2/SoulGasToken.sol
         - packages/contracts-bedrock/src/cannon/MIPS.sol
         - packages/contracts-bedrock/src/cannon/MIPS2.sol
         - packages/contracts-bedrock/src/cannon/MIPS64.sol


### PR DESCRIPTION
Fix CircleCI [issue](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/31/workflows/0499087e-6cc7-4f27-b4e5-08d0c1deaccc/jobs/742):
>          Immutable variables are not allowed in this codebase

