### PR TITLE
Fix CircleCI: op-e2e-cannon-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2172,8 +2172,8 @@ workflows:
           name: op-e2e-cannon-tests
           notify: true
           mentions: "@proofs-team"
-          no_output_timeout: 120m
-          test_timeout: 119m
+          no_output_timeout: 3h
+          test_timeout: 3h
           resource_class: qkc/ax101
           environment_overrides: |
             export OP_E2E_CANNON_ENABLED="true"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2172,8 +2172,8 @@ workflows:
           name: op-e2e-cannon-tests
           notify: true
           mentions: "@proofs-team"
-          no_output_timeout: 60m
-          test_timeout: 59m
+          no_output_timeout: 120m
+          test_timeout: 119m
           resource_class: qkc/ax101
           environment_overrides: |
             export OP_E2E_CANNON_ENABLED="true"


### PR DESCRIPTION
Fix the following error when running the CircleCI [workflow](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/31/workflows/72c4d282-0d6c-4183-999c-23b7403cef3c/jobs/754/parallel-runs/0/steps/0-112).
>panic: test timed out after 59m0s

