### PR TITLE
Fix `Intent.FundDevAccounts`

### DIFF
--- a/op-deployer/pkg/deployer/init.go
+++ b/op-deployer/pkg/deployer/init.go
@@ -89,7 +89,7 @@ func Init(cfg InitConfig) error {
 	intent := &state.Intent{
 		DeploymentStrategy: cfg.DeploymentStrategy,
 		L1ChainID:          cfg.L1ChainID,
-		FundDevAccounts:    true,
+		FundDevAccounts:    false,
 		L1ContractsLocator: artifacts.DefaultL1ContractsLocator,
 		L2ContractsLocator: artifacts.DefaultL2ContractsLocator,
 	}


### PR DESCRIPTION
On this branch, `FundDevAccounts` is set to `true` by default, which is dangerous, though it's  not applied to L2 genesis.

