### PR TITLE
Fix CircleCI: No tests to run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1946,7 +1946,6 @@ workflows:
             - discord
       - docker-build:
           name: <<matrix.docker_name>>-docker-build
-
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           save_image_tag: <<pipeline.git.revision>>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,7 +783,7 @@ jobs:
             TEST_FILES=$(<<parameters.test_list>>)
             if [ -z "$TEST_FILES" ]; then
               echo "No test files to run. Exiting early."
-              circleci step halt
+              exit 0
             fi
           working_directory: packages/contracts-bedrock
       - check-changed:
@@ -808,6 +808,10 @@ jobs:
           name: Run tests
           command: |
             TEST_FILES=$(<<parameters.test_list>>)
+            if [ -z "$TEST_FILES" ]; then
+              echo "No test files to run. Skipping forge test."
+              exit 0
+            fi
             TEST_FILES=$(echo "$TEST_FILES" | sed 's|^test/||')
             MATCH_PATH="./test/{$(echo "$TEST_FILES" | paste -sd "," -)}"
             forge <<parameters.test_command>> <<parameters.test_flags>> --match-path "$MATCH_PATH"
@@ -1942,6 +1946,7 @@ workflows:
             - discord
       - docker-build:
           name: <<matrix.docker_name>>-docker-build
+
           docker_tags: <<pipeline.git.revision>>,<<pipeline.git.branch>>
           save_image_tag: <<pipeline.git.revision>>
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -783,7 +783,7 @@ jobs:
             TEST_FILES=$(<<parameters.test_list>>)
             if [ -z "$TEST_FILES" ]; then
               echo "No test files to run. Exiting early."
-              exit 0
+              circleci step halt
             fi
           working_directory: packages/contracts-bedrock
       - check-changed:


### PR DESCRIPTION
Fix CircleCI test [error](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/31/workflows/0499087e-6cc7-4f27-b4e5-08d0c1deaccc/jobs/714) named `contracts-bedrock-tests-heavy-fuzz-modified` where `test_list` is empty:
```
No tests match the provided pattern:
        match-path: `./test/{}`
Error: No tests to run

Exited with code exit status 1
```

