### PR TITLE
disable native bridge & enable minting L2 native token on L1

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -50,12 +50,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
     event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
     event ETHMigrated(address indexed lockbox, uint256 ethBalance);
-    event PortalMigrated(
-        IETHLockbox oldLockbox,
-        IETHLockbox newLockbox,
-        IAnchorStateRegistry oldAnchorStateRegistry,
-        IAnchorStateRegistry newAnchorStateRegistry
-    );
+    event PortalMigrated(IETHLockbox oldLockbox, IETHLockbox newLockbox, IAnchorStateRegistry oldAnchorStateRegistry, IAnchorStateRegistry newAnchorStateRegistry);
 
     receive() external payable;
 
@@ -126,12 +121,15 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function superchainConfig() external view returns (ISuperchainConfig);
     function superRootsActive() external view returns (bool);
     function systemConfig() external view returns (ISystemConfig);
-    function upgrade(IAnchorStateRegistry _anchorStateRegistry, IETHLockbox _ethLockbox) external;
+    function upgrade(
+        IAnchorStateRegistry _anchorStateRegistry,
+        IETHLockbox _ethLockbox
+    )
+        external;
     function version() external pure returns (string memory);
     function migrateLiquidity() external;
 
-    function addMinter(address _minter) external;
-    function removeMinter(address _minter) external;
+    function setMinter(address _minter) external;
     function mintTransaction(address _to, uint256 _value) external;
     function setNativeDeposit(bool _disable) external;
 

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -50,7 +50,12 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
     event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
     event ETHMigrated(address indexed lockbox, uint256 ethBalance);
-    event PortalMigrated(IETHLockbox oldLockbox, IETHLockbox newLockbox, IAnchorStateRegistry oldAnchorStateRegistry, IAnchorStateRegistry newAnchorStateRegistry);
+    event PortalMigrated(
+        IETHLockbox oldLockbox,
+        IETHLockbox newLockbox,
+        IAnchorStateRegistry oldAnchorStateRegistry,
+        IAnchorStateRegistry newAnchorStateRegistry
+    );
 
     receive() external payable;
 
@@ -121,13 +126,15 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function superchainConfig() external view returns (ISuperchainConfig);
     function superRootsActive() external view returns (bool);
     function systemConfig() external view returns (ISystemConfig);
-    function upgrade(
-        IAnchorStateRegistry _anchorStateRegistry,
-        IETHLockbox _ethLockbox
-    )
-        external;
+    function upgrade(IAnchorStateRegistry _anchorStateRegistry, IETHLockbox _ethLockbox) external;
     function version() external pure returns (string memory);
     function migrateLiquidity() external;
+
+    function addMinter(address _minter) external;
+    function removeMinter(address _minter) external;
+    function mintTransaction(address _to, uint256 _value) external;
+    function disableNativeDeposit() external;
+    function enableNativeDeposit() external;
 
     function __constructor__(uint256 _proofMaturityDelaySeconds) external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -133,8 +133,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function addMinter(address _minter) external;
     function removeMinter(address _minter) external;
     function mintTransaction(address _to, uint256 _value) external;
-    function disableNativeDeposit() external;
-    function enableNativeDeposit() external;
+    function setNativeDeposit(bool _disable) external;
 
     function __constructor__(uint256 _proofMaturityDelaySeconds) external;
 }

--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL1MessagePasser.sol
@@ -21,8 +21,7 @@ interface IL2ToL1MessagePasser {
     function messageNonce() external view returns (uint256);
     function sentMessages(bytes32) external view returns (bool);
     function version() external view returns (string memory);
-    function enableNativeDeposit() external;
-    function disableNativeDeposit() external;
+    function setNativeDeposit(bool _disable) external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L2/IL2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/interfaces/L2/IL2ToL1MessagePasser.sol
@@ -21,6 +21,8 @@ interface IL2ToL1MessagePasser {
     function messageNonce() external view returns (uint256);
     function sentMessages(bytes32) external view returns (bool);
     function version() external view returns (string memory);
+    function enableNativeDeposit() external;
+    function disableNativeDeposit() external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -760,7 +760,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
-        emit TransactionDeposited(Constants.DEPOSITOR_ACCOUNT, _to, DEPOSIT_VERSION, opaqueData);
+        emit TransactionDeposited(Constants.DEPOSITOR_ACCOUNT2, _to, DEPOSIT_VERSION, opaqueData);
     }
 
     /// @notice set native deposit flag. Pass true to disable.
@@ -785,7 +785,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
         emit TransactionDeposited(
-            Constants.DEPOSITOR_ACCOUNT, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
+            Constants.DEPOSITOR_ACCOUNT2, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
         );
     }
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -135,8 +135,8 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @custom:storage-location erc7201:openzeppelin.storage.OptimismPortal2.QKCConfigStorage
 
     struct QKCConfigStorage {
-        /// @notice The minters for migrating existing L1 token to L2 native token.
-        mapping(address => bool) minters;
+        /// @notice The minter for migrating existing L1 token to L2 native token.
+        address minter;
         bool disableNativeDeposit;
     }
 
@@ -189,10 +189,8 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         IAnchorStateRegistry newAnchorStateRegistry
     );
 
-    /// @notice Emitted when a minter is added.
-    event MinterAdded(address indexed minter);
-    /// @notice Emitted when a minter is removed.
-    event MinterRemoved(address indexed minter);
+    /// @notice Emitted when a minter is set.
+    event MinterSet(address indexed minter);
     /// @notice Emitted when native deposit is disabled.
     event NativeDepositDisabled();
     /// @notice Emitted when native deposit is enabled.
@@ -216,9 +214,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Thrown when the gas limit for a deposit is too low.
     error OptimismPortal_GasLimitTooLow();
 
-    // @notice Thrown when native token is deposited to the portal contract.
+    // @notice Thrown when native token is deposited to the portal contract when disabled.
     //         For swc, the native token is actually qkc so we need to disable ETH deposits.
-    error NativeDepositDisabled();
+    error NativeDepositForbidden();
 
     // @notice Thrown when a minter is added twice
     error MinterAlreadyAdded();
@@ -735,46 +733,25 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         _migrateLiquidity();
     }
 
-    /// @notice Add a minter to the OptimismPortal contract.
-    function addMinter(address _minter) external {
+    /// @notice Add a minter to the OptimismPortal contract. To disable, set an empty value.
+    function setMinter(address _minter) external {
         if (msg.sender != proxyAdminOwner()) {
             revert OptimismPortal_Unauthorized();
         }
         QKCConfigStorage storage $ = _getQKCConfigStorage();
-        if ($.minters[_minter]) {
-            revert MinterAlreadyAdded();
-        }
-        $.minters[_minter] = true;
-        emit MinterAdded(_minter);
-    }
-
-    /// @notice Remove a minter from the OptimismPortal contract.
-    function removeMinter(address _minter) external {
-        if (msg.sender != proxyAdminOwner()) {
-            revert OptimismPortal_Unauthorized();
-        }
-        QKCConfigStorage storage $ = _getQKCConfigStorage();
-        if (!$.minters[_minter]) {
-            revert MinterNotExist();
-        }
-        delete $.minters[_minter];
-        emit MinterRemoved(_minter);
+        $.minter = _minter;
+        emit MinterSet(_minter);
     }
 
     /// @notice Mint a specific amount of L2 native token to an address.
-    function mintTransaction(address _to, uint256 _value) external {
+    function mintTransaction(address _to, uint256 _value) external metered(RECEIVE_DEFAULT_GAS_LIMIT) {
         QKCConfigStorage storage $ = _getQKCConfigStorage();
-        if (!$.minters[msg.sender]) {
+        if (msg.sender != $.minter) {
             revert OptimismPortal_Unauthorized();
         }
 
-        if (to == address(0)) {
+        if (_to == address(0)) {
             revert OptimismPortal_BadTarget();
-        }
-        // Transform the from-address to its alias if the caller is a contract.
-        address from = msg.sender;
-        if (!EOA.isSenderEOA()) {
-            from = AddressAliasHelper.applyL1ToL2Alias(msg.sender);
         }
         // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
         // We use opaque data so that we can update the TransactionDeposited event in the future
@@ -783,50 +760,28 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
-        emit TransactionDeposited(from, _to, DEPOSIT_VERSION, opaqueData);
+        emit TransactionDeposited(Constants.DEPOSITOR_ACCOUNT, _to, DEPOSIT_VERSION, opaqueData);
     }
 
-    /// @notice Disable native token deposit.
-    function disableNativeDeposit() external {
+    /// @notice set native deposit flag. Pass true to disable.
+    function setNativeDeposit(bool _disable) external {
         if (msg.sender != proxyAdminOwner()) {
             revert OptimismPortal_Unauthorized();
         }
-
         QKCConfigStorage storage $ = _getQKCConfigStorage();
-        $.disableNativeDeposit = true;
-        emit NativeDepositDisabled();
+        $.disableNativeDeposit = _disable;
+        if (_disable) {
+            emit NativeDepositDisabled();
+        } else {
+            emit NativeDepositEnabled();
+        }
 
         // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
         // We use opaque data so that we can update the TransactionDeposited event in the future
         // without breaking the current interface.
         bytes memory opaqueData = abi.encodePacked(
-            0, 0, SYSTEM_DEPOSIT_GAS_LIMIT, false, abi.encodeCall(IL2ToL1MessagePasser.disableNativeDeposit, ())
+            uint256(0), uint256(0), SYSTEM_DEPOSIT_GAS_LIMIT, false, abi.encodeCall(IL2ToL1MessagePasser.setNativeDeposit, (_disable))
         );
-
-        // Emit a TransactionDeposited event so that the rollup node can derive a deposit
-        // transaction for this deposit.
-        emit TransactionDeposited(
-            Constants.DEPOSITOR_ACCOUNT, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
-        );
-    }
-
-    /// @notice Enable native token deposit.
-    function enableNativeDeposit() external {
-        if (msg.sender != proxyAdminOwner()) {
-            revert OptimismPortal_Unauthorized();
-        }
-
-        QKCConfigStorage storage $ = _getQKCConfigStorage();
-        $.disableNativeDeposit = false;
-        emit NativeDepositEnabled();
-
-        // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
-        // We use opaque data so that we can update the TransactionDeposited event in the future
-        // without breaking the current interface.
-        bytes memory opaqueData = abi.encodePacked(
-            0, 0, SYSTEM_DEPOSIT_GAS_LIMIT, false, abi.encodeCall(IL2ToL1MessagePasser.enableNativeDeposit, ())
-        );
-
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
         emit TransactionDeposited(
@@ -859,7 +814,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         if (msg.value > 0) {
             QKCConfigStorage storage $ = _getQKCConfigStorage();
             if ($.disableNativeDeposit) {
-                revert NativeDepositDisabled();
+                revert NativeDepositForbidden();
             }
         }
         // Lock the ETH in the ETHLockbox.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -218,12 +218,6 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     //         For swc, the native token is actually qkc so we need to disable ETH deposits.
     error NativeDepositForbidden();
 
-    // @notice Thrown when a minter is added twice
-    error MinterAlreadyAdded();
-
-    // @notice Thrown when removing a minter which doesn't exist
-    error MinterNotExist();
-
     /// @notice Thrown when the target of a withdrawal is not a proper dispute game.
     error OptimismPortal_ImproperDisputeGame();
 
@@ -408,9 +402,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @param _newLockbox The address of the new ETHLockbox contract.
     function migrateToSuperRoots(IETHLockbox _newLockbox, IAnchorStateRegistry _newAnchorStateRegistry) external {
         // Make sure the caller is the owner of the ProxyAdmin.
-        if (msg.sender != proxyAdminOwner()) {
-            revert OptimismPortal_Unauthorized();
-        }
+        if (msg.sender != proxyAdminOwner()) revert OptimismPortal_Unauthorized();
 
         // Chains can use this method to swap the proof method from Output Roots to Super Roots
         // without joining the interop set. In this case, the old and new lockboxes will be the
@@ -727,9 +719,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     /// @notice Migrates the total ETH balance to the ETHLockbox.
     function migrateLiquidity() public {
-        if (msg.sender != proxyAdminOwner()) {
-            revert OptimismPortal_Unauthorized();
-        }
+        if (msg.sender != proxyAdminOwner()) revert OptimismPortal_Unauthorized();
         _migrateLiquidity();
     }
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -187,6 +187,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Thrown when the gas limit for a deposit is too low.
     error OptimismPortal_GasLimitTooLow();
 
+    // @notice For swc, the native token is actually qkc so we need to disable ETH deposits
+    error NativeDepositDisabled();
+
     /// @notice Thrown when the target of a withdrawal is not a proper dispute game.
     error OptimismPortal_ImproperDisputeGame();
 
@@ -714,6 +717,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         payable
         metered(_gasLimit)
     {
+        if (msg.value > 0) {
+            revert NativeDepositDisabled();
+        }
         // Lock the ETH in the ETHLockbox.
         if (msg.value > 0) ethLockbox.lockETH{ value: msg.value }();
 

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -11,6 +11,7 @@ import { ReinitializableBase } from "src/universal/ReinitializableBase.sol";
 import { EOA } from "src/libraries/EOA.sol";
 import { SafeCall } from "src/libraries/SafeCall.sol";
 import { Constants } from "src/libraries/Constants.sol";
+import { Predeploys } from "src/libraries/Predeploys.sol";
 import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { SecureMerkleTrie } from "src/libraries/trie/SecureMerkleTrie.sol";
@@ -24,6 +25,7 @@ import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
 import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
 import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
 import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
 
@@ -126,6 +128,24 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Whether the OptimismPortal is using Super Roots or Output Roots.
     bool public superRootsActive;
 
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.OptimismPortal2.QKCConfigStorage")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _QKC_CONFIG_STORAGE_LOCATION =
+        0xb42b8bfdf1143b9dfcdc891f15a039d3c36301d501f5a44f62223d852a602a00;
+    /// @custom:storage-location erc7201:openzeppelin.storage.OptimismPortal2.QKCConfigStorage
+
+    struct QKCConfigStorage {
+        /// @notice The minters for migrating existing L1 token to L2 native token.
+        mapping(address => bool) minters;
+        bool disableNativeDeposit;
+    }
+
+    function _getQKCConfigStorage() private pure returns (QKCConfigStorage storage $) {
+        assembly {
+            $.slot := _QKC_CONFIG_STORAGE_LOCATION
+        }
+    }
+
     /// @notice Emitted when a transaction is deposited from L1 to L2. The parameters of this event
     ///         are read by the rollup node and used to derive deposit transactions on L2.
     /// @param from       Address that triggered the deposit transaction.
@@ -169,6 +189,15 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         IAnchorStateRegistry newAnchorStateRegistry
     );
 
+    /// @notice Emitted when a minter is added.
+    event MinterAdded(address indexed minter);
+    /// @notice Emitted when a minter is removed.
+    event MinterRemoved(address indexed minter);
+    /// @notice Emitted when native deposit is disabled.
+    event NativeDepositDisabled();
+    /// @notice Emitted when native deposit is enabled.
+    event NativeDepositEnabled();
+
     /// @notice Thrown when a withdrawal has already been finalized.
     error OptimismPortal_AlreadyFinalized();
 
@@ -187,8 +216,15 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @notice Thrown when the gas limit for a deposit is too low.
     error OptimismPortal_GasLimitTooLow();
 
-    // @notice For swc, the native token is actually qkc so we need to disable ETH deposits
+    // @notice Thrown when native token is deposited to the portal contract.
+    //         For swc, the native token is actually qkc so we need to disable ETH deposits.
     error NativeDepositDisabled();
+
+    // @notice Thrown when a minter is added twice
+    error MinterAlreadyAdded();
+
+    // @notice Thrown when removing a minter which doesn't exist
+    error MinterNotExist();
 
     /// @notice Thrown when the target of a withdrawal is not a proper dispute game.
     error OptimismPortal_ImproperDisputeGame();
@@ -374,7 +410,9 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @param _newLockbox The address of the new ETHLockbox contract.
     function migrateToSuperRoots(IETHLockbox _newLockbox, IAnchorStateRegistry _newAnchorStateRegistry) external {
         // Make sure the caller is the owner of the ProxyAdmin.
-        if (msg.sender != proxyAdminOwner()) revert OptimismPortal_Unauthorized();
+        if (msg.sender != proxyAdminOwner()) {
+            revert OptimismPortal_Unauthorized();
+        }
 
         // Chains can use this method to swap the proof method from Output Roots to Super Roots
         // without joining the interop set. In this case, the old and new lockboxes will be the
@@ -691,8 +729,109 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     /// @notice Migrates the total ETH balance to the ETHLockbox.
     function migrateLiquidity() public {
-        if (msg.sender != proxyAdminOwner()) revert OptimismPortal_Unauthorized();
+        if (msg.sender != proxyAdminOwner()) {
+            revert OptimismPortal_Unauthorized();
+        }
         _migrateLiquidity();
+    }
+
+    /// @notice Add a minter to the OptimismPortal contract.
+    function addMinter(address _minter) external {
+        if (msg.sender != proxyAdminOwner()) {
+            revert OptimismPortal_Unauthorized();
+        }
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        if ($.minters[_minter]) {
+            revert MinterAlreadyAdded();
+        }
+        $.minters[_minter] = true;
+        emit MinterAdded(_minter);
+    }
+
+    /// @notice Remove a minter from the OptimismPortal contract.
+    function removeMinter(address _minter) external {
+        if (msg.sender != proxyAdminOwner()) {
+            revert OptimismPortal_Unauthorized();
+        }
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        if (!$.minters[_minter]) {
+            revert MinterNotExist();
+        }
+        delete $.minters[_minter];
+        emit MinterRemoved(_minter);
+    }
+
+    /// @notice Mint a specific amount of L2 native token to an address.
+    function mintTransaction(address _to, uint256 _value) external {
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        if (!$.minters[msg.sender]) {
+            revert OptimismPortal_Unauthorized();
+        }
+
+        if (to == address(0)) {
+            revert OptimismPortal_BadTarget();
+        }
+        // Transform the from-address to its alias if the caller is a contract.
+        address from = msg.sender;
+        if (!EOA.isSenderEOA()) {
+            from = AddressAliasHelper.applyL1ToL2Alias(msg.sender);
+        }
+        // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
+        // We use opaque data so that we can update the TransactionDeposited event in the future
+        // without breaking the current interface.
+        bytes memory opaqueData = abi.encodePacked(_value, _value, RECEIVE_DEFAULT_GAS_LIMIT, false, bytes(""));
+
+        // Emit a TransactionDeposited event so that the rollup node can derive a deposit
+        // transaction for this deposit.
+        emit TransactionDeposited(from, _to, DEPOSIT_VERSION, opaqueData);
+    }
+
+    /// @notice Disable native token deposit.
+    function disableNativeDeposit() external {
+        if (msg.sender != proxyAdminOwner()) {
+            revert OptimismPortal_Unauthorized();
+        }
+
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        $.disableNativeDeposit = true;
+        emit NativeDepositDisabled();
+
+        // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
+        // We use opaque data so that we can update the TransactionDeposited event in the future
+        // without breaking the current interface.
+        bytes memory opaqueData = abi.encodePacked(
+            0, 0, SYSTEM_DEPOSIT_GAS_LIMIT, false, abi.encodeCall(IL2ToL1MessagePasser.disableNativeDeposit, ())
+        );
+
+        // Emit a TransactionDeposited event so that the rollup node can derive a deposit
+        // transaction for this deposit.
+        emit TransactionDeposited(
+            Constants.DEPOSITOR_ACCOUNT, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
+        );
+    }
+
+    /// @notice Enable native token deposit.
+    function enableNativeDeposit() external {
+        if (msg.sender != proxyAdminOwner()) {
+            revert OptimismPortal_Unauthorized();
+        }
+
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        $.disableNativeDeposit = false;
+        emit NativeDepositEnabled();
+
+        // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
+        // We use opaque data so that we can update the TransactionDeposited event in the future
+        // without breaking the current interface.
+        bytes memory opaqueData = abi.encodePacked(
+            0, 0, SYSTEM_DEPOSIT_GAS_LIMIT, false, abi.encodeCall(IL2ToL1MessagePasser.enableNativeDeposit, ())
+        );
+
+        // Emit a TransactionDeposited event so that the rollup node can derive a deposit
+        // transaction for this deposit.
+        emit TransactionDeposited(
+            Constants.DEPOSITOR_ACCOUNT, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
+        );
     }
 
     /// @notice Accepts deposits of ETH and data, and emits a TransactionDeposited event for use in
@@ -718,7 +857,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         metered(_gasLimit)
     {
         if (msg.value > 0) {
-            revert NativeDepositDisabled();
+            QKCConfigStorage storage $ = _getQKCConfigStorage();
+            if ($.disableNativeDeposit) {
+                revert NativeDepositDisabled();
+            }
         }
         // Lock the ETH in the ETHLockbox.
         if (msg.value > 0) ethLockbox.lockETH{ value: msg.value }();

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -128,23 +128,17 @@ contract L2ToL1MessagePasser is ISemver {
         return Encoding.encodeVersionedNonce(msgNonce, MESSAGE_VERSION);
     }
 
-    /// @notice This function is used to enable the native deposit functionality
-    function enableNativeDeposit() external {
+    /// @notice set native deposit flag. Pass true to disable.
+    function setNativeDeposit(bool _disable) external {
         if (msg.sender != Constants.DEPOSITOR_ACCOUNT) {
-            revert("L2ToL1MessagePasser: Only the depositor can enable native deposits");
+            revert("L2ToL1MessagePasser: Only the depositor can enable/disable native deposits");
         }
         QKCConfigStorage storage $ = _getQKCConfigStorage();
-        $.disableNativeDeposit = false;
-        emit NativeDepositEnabled();
-    }
-
-    /// @notice This function is used to disable the native deposit functionality
-    function disableNativeDeposit() external {
-        if (msg.sender != Constants.DEPOSITOR_ACCOUNT) {
-            revert("L2ToL1MessagePasser: Only the depositor can disable native deposits");
+        $.disableNativeDeposit = _disable;
+        if (_disable) {
+            emit NativeDepositDisabled();
+        } else {
+            emit NativeDepositEnabled();
         }
-        QKCConfigStorage storage $ = _getQKCConfigStorage();
-        $.disableNativeDeposit = true;
-        emit NativeDepositDisabled();
     }
 }

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -130,8 +130,8 @@ contract L2ToL1MessagePasser is ISemver {
 
     /// @notice set native deposit flag. Pass true to disable.
     function setNativeDeposit(bool _disable) external {
-        if (msg.sender != Constants.DEPOSITOR_ACCOUNT) {
-            revert("L2ToL1MessagePasser: Only the depositor can enable/disable native deposits");
+        if (msg.sender != Constants.DEPOSITOR_ACCOUNT2) {
+            revert("L2ToL1MessagePasser: Only the depositor #2 can enable/disable native deposits");
         }
         QKCConfigStorage storage $ = _getQKCConfigStorage();
         $.disableNativeDeposit = _disable;

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -6,6 +6,7 @@ import { Types } from "src/libraries/Types.sol";
 import { Hashing } from "src/libraries/Hashing.sol";
 import { Encoding } from "src/libraries/Encoding.sol";
 import { Burn } from "src/libraries/Burn.sol";
+import { Constants } from "src/libraries/Constants.sol";
 
 // Interfaces
 import { ISemver } from "interfaces/universal/ISemver.sol";
@@ -29,6 +30,22 @@ contract L2ToL1MessagePasser is ISemver {
     /// @notice A unique value hashed with each withdrawal.
     uint240 internal msgNonce;
 
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L2ToL1MessagePasser.QKCConfigStorage")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _QKC_CONFIG_STORAGE_LOCATION =
+        0x750f1ab2ed0ba2a4405b31f7b30e394ba3545975e71082ba3e508022a159f900;
+    /// @custom:storage-location erc7201:openzeppelin.storage.L2ToL1MessagePasser.QKCConfigStorage
+
+    struct QKCConfigStorage {
+        bool disableNativeDeposit;
+    }
+
+    function _getQKCConfigStorage() private pure returns (QKCConfigStorage storage $) {
+        assembly {
+            $.slot := _QKC_CONFIG_STORAGE_LOCATION
+        }
+    }
+
     /// @notice Emitted any time a withdrawal is initiated.
     /// @param nonce          Unique value corresponding to each withdrawal.
     /// @param sender         The L2 account address which initiated the withdrawal.
@@ -50,6 +67,11 @@ contract L2ToL1MessagePasser is ISemver {
     /// @notice Emitted when the balance of this contract is burned.
     /// @param amount Amount of ETh that was burned.
     event WithdrawerBalanceBurnt(uint256 indexed amount);
+
+    /// @notice Emitted when native deposit is disabled.
+    event NativeDepositDisabled();
+    /// @notice Emitted when native deposit is enabled.
+    event NativeDepositEnabled();
 
     /// @custom:semver 1.1.2
     string public constant version = "1.1.2";
@@ -100,5 +122,25 @@ contract L2ToL1MessagePasser is ISemver {
     /// @return Nonce of the next message to be sent, with added message version.
     function messageNonce() public view returns (uint256) {
         return Encoding.encodeVersionedNonce(msgNonce, MESSAGE_VERSION);
+    }
+
+    /// @notice This function is used to enable the native deposit functionality
+    function enableNativeDeposit() external {
+        if (msg.sender != Constants.DEPOSITOR_ACCOUNT) {
+            revert("L2ToL1MessagePasser: Only the depositor can enable native deposits");
+        }
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        $.disableNativeDeposit = false;
+        emit NativeDepositEnabled();
+    }
+
+    /// @notice This function is used to disable the native deposit functionality
+    function disableNativeDeposit() external {
+        if (msg.sender != Constants.DEPOSITOR_ACCOUNT) {
+            revert("L2ToL1MessagePasser: Only the depositor can disable native deposits");
+        }
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        $.disableNativeDeposit = true;
+        emit NativeDepositDisabled();
     }
 }

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -96,6 +96,10 @@ contract L2ToL1MessagePasser is ISemver {
     /// @param _gasLimit Minimum gas limit for executing the message on L1.
     /// @param _data     Data to forward to L1 target.
     function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) public payable {
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        if ($.disableNativeDeposit && msg.value > 0) {
+            revert("native deposit/withdraw is disabled");
+        }
         bytes32 withdrawalHash = Hashing.hashWithdrawal(
             Types.WithdrawalTransaction({
                 nonce: messageNonce(),

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -37,6 +37,8 @@ library Constants {
     /// @notice The address that represents the system caller responsible for L1 attributes
     ///         transactions.
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
+    /// @notice Another fixed address to avoid potential risky calls for deposit tx on L2.
+    address internal constant DEPOSITOR_ACCOUNT2 = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0002;
 
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.


### PR DESCRIPTION
As a plan B for original CGT feature, we need to disable eth bridging on L1.

And we also need to enable minting L2 native token on L1 in order to migrating existing tokens on L1.