### PR TITLE
Compile error: invalid checksum address

### DIFF
--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -38,7 +38,7 @@ library Constants {
     ///         transactions.
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
     /// @notice Another fixed address to avoid potential risky calls for deposit tx on L2.
-    address internal constant DEPOSITOR_ACCOUNT2 = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0002;
+    address internal constant DEPOSITOR_ACCOUNT2 = 0xDeAddEAddeADdeADdEaDdEaddeadDeADdEAD0002;
 
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.


### PR DESCRIPTION
The compiler complains: `This looks like an address but has an invalid checksum. Correct checksummed address: "0xDeAddEAddeADdeADdEaDdEaddeadDeADdEAD0002". If this is not used as an address, please prepend '00'. For more information please see https://docs.soliditylang.org/en/develop/types.html#address-literalssolidity(9429)`