### PR TITLE
Fix CircleCI: publish-cannon-prestates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2191,19 +2191,19 @@ workflows:
           requires:
             - contracts-bedrock-build
             - cannon-prestate
-      - publish-cannon-prestates:
-          context:
-            - slack
-            - oplabs-network-optimism-io-bucket
-            - circleci-repo-readonly-authenticated-github-token
-            - discord
-          requires:
-            - cannon-prestate
-            - op-e2e-cannon-tests
-          filters:
-            branches:
-              only:
-                - op-es
+      # - publish-cannon-prestates:
+      #     context:
+      #       - slack
+      #       - oplabs-network-optimism-io-bucket
+      #       - circleci-repo-readonly-authenticated-github-token
+      #       - discord
+      #     requires:
+      #       - cannon-prestate
+      #       - op-e2e-cannon-tests
+      #     filters:
+      #       branches:
+      #         only:
+      #           - op-es
 
   # develop-kontrol-tests:
   #   when:


### PR DESCRIPTION
We got a [failure](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/42/workflows/1d0f669a-2c83-4e87-8cfc-8d23df2fe4dc/jobs/920) on  CircleCI workflow `develop-fault-proofs`, job `publish-cannon-prestates`. The log indicates we may need a gcloud auth login with `GOOGLE_APPLICATION_CREDENTIALS` to publish cannon prestates to the Google cloud.

So far, no benefit has been seen in uploading the data. Therefore, it is suggested that this step be skipped since storing GOOGLE_APPLICATION_CREDENTIALS could introduce a security risk.


