### PR TITLE
avoid conflict with `OptimisticBlockDepositSenderAddress`

### DIFF
--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -750,7 +750,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
-        emit TransactionDeposited(Constants.DEPOSITOR_ACCOUNT2, _to, DEPOSIT_VERSION, opaqueData);
+        emit TransactionDeposited(Constants.QKC_DEPOSITOR_ACCOUNT, _to, DEPOSIT_VERSION, opaqueData);
     }
 
     /// @notice set native deposit flag. Pass true to disable.
@@ -775,7 +775,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
         emit TransactionDeposited(
-            Constants.DEPOSITOR_ACCOUNT2, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
+            Constants.QKC_DEPOSITOR_ACCOUNT, Predeploys.L2_TO_L1_MESSAGE_PASSER, DEPOSIT_VERSION, opaqueData
         );
     }
 

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -130,7 +130,7 @@ contract L2ToL1MessagePasser is ISemver {
 
     /// @notice set native deposit flag. Pass true to disable.
     function setNativeDeposit(bool _disable) external {
-        if (msg.sender != Constants.DEPOSITOR_ACCOUNT2) {
+        if (msg.sender != Constants.QKC_DEPOSITOR_ACCOUNT) {
             revert("L2ToL1MessagePasser: Only the depositor #2 can enable/disable native deposits");
         }
         QKCConfigStorage storage $ = _getQKCConfigStorage();

--- a/packages/contracts-bedrock/src/libraries/Constants.sol
+++ b/packages/contracts-bedrock/src/libraries/Constants.sol
@@ -38,7 +38,7 @@ library Constants {
     ///         transactions.
     address internal constant DEPOSITOR_ACCOUNT = 0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001;
     /// @notice Another fixed address to avoid potential risky calls for deposit tx on L2.
-    address internal constant DEPOSITOR_ACCOUNT2 = 0xDeAddEAddeADdeADdEaDdEaddeadDeADdEAD0002;
+    address internal constant QKC_DEPOSITOR_ACCOUNT = 0xDEAddeaDDEADDEadDeaDDEaDDEADDeaddEaDfffF;
 
     /// @notice Returns the default values for the ResourceConfig. These are the recommended values
     ///         for a production network.


### PR DESCRIPTION
The `0xDeAddEAddeADdeADdEaDdEaddeadDeADdEAD0002` is already used [here](https://github.com/ethereum-optimism/optimism/blob/9f1eaf58918d0fbb309f185a1de655963d1f0869/op-node/rollup/interop/managed/attributes.go#L18), this PR chooses another value that won't conflict in short period.