### PR TITLE
introduce QKCPriceRatio

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -23,8 +23,8 @@ const (
 	L1InfoFuncIsthmusSignature = "setL1BlockValuesIsthmus()"
 	L1InfoArguments            = 8
 	L1InfoBedrockLen           = 4 + 32*L1InfoArguments
-	L1InfoEcotoneLen           = 4 + 32*5         // after Ecotone upgrade, args are packed into 5 32-byte slots
-	L1InfoIsthmusLen           = 4 + 32*5 + 4 + 8 // after Isthmus upgrade, additionally pack in operator fee scalar and constant
+	L1InfoEcotoneLen           = 4 + 32*5                              // after Ecotone upgrade, args are packed into 5 32-byte slots
+	L1InfoIsthmusLen           = 4 + 32*5 + 4 + 8 + /*added by qkc*/ 8 // after Isthmus upgrade, additionally pack in operator fee scalar and constant
 )
 
 var (
@@ -62,6 +62,8 @@ type L1BlockInfo struct {
 
 	OperatorFeeScalar   uint32 // added by Isthmus upgrade
 	OperatorFeeConstant uint64 // added by Isthmus upgrade
+
+	QKCPriceRatio uint64 // added by qkc
 }
 
 // Bedrock Binary Format
@@ -320,6 +322,9 @@ func marshalBinaryWithSignature(info *L1BlockInfo, signature []byte) ([]byte, er
 	if err := binary.Write(w, binary.BigEndian, info.OperatorFeeConstant); err != nil {
 		return nil, err
 	}
+	if err := binary.Write(w, binary.BigEndian, info.QKCPriceRatio); err != nil {
+		return nil, err
+	}
 	return w.Bytes(), nil
 }
 
@@ -365,6 +370,9 @@ func unmarshalBinaryWithSignatureAndData(info *L1BlockInfo, signature []byte, da
 		return ErrInvalidIsthmusFormat
 	}
 	if err := binary.Read(r, binary.BigEndian, &info.OperatorFeeConstant); err != nil {
+		return ErrInvalidIsthmusFormat
+	}
+	if err := binary.Read(r, binary.BigEndian, &info.QKCPriceRatio); err != nil {
 		return ErrInvalidIsthmusFormat
 	}
 	if !solabi.EmptyReader(r) {
@@ -445,6 +453,7 @@ func L1InfoDeposit(rollupCfg *rollup.Config, sysCfg eth.SystemConfig, seqNumber 
 			operatorFee := sysCfg.OperatorFee()
 			l1BlockInfo.OperatorFeeScalar = operatorFee.Scalar
 			l1BlockInfo.OperatorFeeConstant = operatorFee.Constant
+			l1BlockInfo.QKCPriceRatio = sysCfg.QKCPriceRatio
 		}
 
 		if isIsthmusActivated {

--- a/op-node/rollup/derive/system_config.go
+++ b/op-node/rollup/derive/system_config.go
@@ -23,6 +23,7 @@ var (
 	SystemConfigUpdateUnsafeBlockSigner = common.Hash{31: 3}
 	SystemConfigUpdateEIP1559Params     = common.Hash{31: 4}
 	SystemConfigUpdateOperatorFeeParams = common.Hash{31: 5}
+	SystemConfigUpdateQKCPriceRatio     = common.Hash{31: 255}
 )
 
 var (

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -526,6 +526,8 @@ type SystemConfig struct {
 	// not marshal the EIP1559Params field. The presence of this field in
 	// pre-Holocene codebases causes the rollup config to be rejected.
 	MarshalPreHolocene bool `json:"-"`
+
+	QKCPriceRatio uint64 `json:"qkcPriceRatio,omitempty"`
 }
 
 func (sysCfg SystemConfig) MarshalJSON() ([]byte, error) {

--- a/packages/contracts-bedrock/src/L1/SystemConfig.sol
+++ b/packages/contracts-bedrock/src/L1/SystemConfig.sol
@@ -109,9 +109,26 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
     /// @notice Blobbasefee scalar value. Part of the L2 fee calculation since the Ecotone network upgrade.
     uint32 public blobbasefeeScalar;
 
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.SystemConfig.QKCConfigStorage")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _QKC_CONFIG_STORAGE_LOCATION =
+        0x4a9fff901ef6efd38ef74f95fd1c0cb935aed3e47b9d196dc09e127b28d2a200;
+    /// @custom:storage-location erc7201:openzeppelin.storage.SystemConfig.QKCConfigStorage
+
+    struct QKCConfigStorage {
+        /// @notice The price ratio for eth/qkc .
+        uint64 QKCPriceRatio;
+    }
+
+    function _getQKCConfigStorage() private pure returns (QKCConfigStorage storage $) {
+        assembly {
+            $.slot := _QKC_CONFIG_STORAGE_LOCATION
+        }
+    }
     /// @notice The configuration for the deposit fee market.
     ///         Used by the OptimismPortal to meter the cost of buying L2 gas on L1.
     ///         Set as internal with a getter so that the struct is returned instead of a tuple.
+
     IResourceMetering.ResourceConfig internal _resourceConfig;
 
     /// @notice The EIP-1559 base fee max change denominator.
@@ -358,6 +375,16 @@ contract SystemConfig is OwnableUpgradeable, ReinitializableBase, ISemver {
 
         bytes memory data = abi.encode(overhead, scalar);
         emit ConfigUpdate(VERSION, UpdateType.FEE_SCALARS, data);
+    }
+
+    /// @notice Updates QKCPriceRatio. Can only be called by the owner.
+    /// @param _QKCPriceRatio     New QKCPriceRatio value.
+    function setQKCPriceRatio(uint64 _QKCPriceRatio) external onlyOwner {
+        QKCConfigStorage storage qkcConfig = _getQKCConfigStorage();
+        qkcConfig.QKCPriceRatio = _QKCPriceRatio;
+
+        bytes memory data = abi.encode(_QKCPriceRatio);
+        emit ConfigUpdate(VERSION, UpdateType(uint8(255))/* a conflict-free enum value */, data);
     }
 
     /// @notice Updates the L2 gas limit. Can only be called by the owner.

--- a/packages/contracts-bedrock/src/L2/L1Block.sol
+++ b/packages/contracts-bedrock/src/L2/L1Block.sol
@@ -93,22 +93,23 @@ contract L1Block is ISemver {
         is_ = false;
     }
 
-    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L1Block.HistoryHashesStorage")) - 1)) &
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L1Block.QKCStorage")) - 1)) &
     // ~bytes32(uint256(0xff))
-    bytes32 private constant _L1BLOCK_HISTORY_HASHES_LOCATION =
-        0xb6e35d777715793a0808adb4ab3d51fc56065457feaf3a18bd958afef33bef00;
+    bytes32 private constant _L1BLOCK_QKC_STORAGE_LOCATION =
+        0x08cf03a46fb7f94e89dfdac731354f0694e6f39dbb491277b16fec4dfaca0800;
     /// @notice size of historyHashes.
     uint256 internal constant HISTORY_SIZE = 8192;
-    /// @custom:storage-location erc7201:openzeppelin.storage.L1Block.HistoryHashesStorage
+    /// @custom:storage-location erc7201:openzeppelin.storage.L1Block.QKCStorage
 
-    struct HistoryHashesStorage {
+    struct QKCStorage {
         /// @notice The 8191 history L1 blockhashes and 1 latest L1 blockhash.
         bytes32[HISTORY_SIZE] historyHashes;
+        uint64 QKCPriceRatio;
     }
 
-    function _getHistoryHashesStorage() private pure returns (HistoryHashesStorage storage $) {
+    function _getQKCStorage() private pure returns (QKCStorage storage $) {
         assembly {
-            $.slot := _L1BLOCK_HISTORY_HASHES_LOCATION
+            $.slot := _L1BLOCK_QKC_STORAGE_LOCATION
         }
     }
 
@@ -192,7 +193,7 @@ contract L1Block is ISemver {
             sstore(batcherHash.slot, calldataload(132)) // bytes32
         }
 
-        HistoryHashesStorage storage $ = _getHistoryHashesStorage();
+        QKCStorage storage $ = _getQKCStorage();
         $.historyHashes[number % HISTORY_SIZE] = hash;
     }
 
@@ -211,7 +212,7 @@ contract L1Block is ISemver {
             lower = upper - HISTORY_SIZE + 1;
         }
         if (_historyNumber >= lower && _historyNumber < upper) {
-            HistoryHashesStorage storage $ = _getHistoryHashesStorage();
+            QKCStorage storage $ = _getQKCStorage();
             return $.historyHashes[_historyNumber % HISTORY_SIZE];
         } else {
             return bytes32(0);
@@ -260,6 +261,13 @@ contract L1Block is ISemver {
         assembly {
             // operatorFeeScalar (uint32), operatorFeeConstant (uint64)
             sstore(operatorFeeConstant.slot, shr(160, calldataload(164)))
+        }
+
+        QKCStorage storage $ = _getQKCStorage();
+        assembly {
+            let baseSlot := $.slot
+            // QKCPriceRatio (uint64)
+            sstore(add(baseSlot, HISTORY_SIZE), shr(192, calldataload(176)))
         }
     }
 }


### PR DESCRIPTION
1. add `QKCPriceRatio` to L1Block, activated at `ithmus`.
2. use it when computing L1 cost (TODO)

Note: we'll need to ensure it doesn't break for future HFs after each merge.