### PR TITLE
CircleCI: fix semgrep

### DIFF
--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -216,7 +216,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
 
     // @notice Thrown when native token is deposited to the portal contract when disabled.
     //         For swc, the native token is actually qkc so we need to disable ETH deposits.
-    error NativeDepositForbidden();
+    error OptimismPortal_NativeDepositForbidden();
 
     /// @notice Thrown when the target of a withdrawal is not a proper dispute game.
     error OptimismPortal_ImproperDisputeGame();

--- a/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
+++ b/packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
@@ -73,6 +73,9 @@ contract L2ToL1MessagePasser is ISemver {
     /// @notice Emitted when native deposit is enabled.
     event NativeDepositEnabled();
 
+    /// @notice Error for disabled native deposit/withdraw.
+    error L2ToL1MessagePasser_NativeDepositDisabled();
+
     /// @custom:semver 1.1.2
     string public constant version = "1.1.2";
 
@@ -98,7 +101,7 @@ contract L2ToL1MessagePasser is ISemver {
     function initiateWithdrawal(address _target, uint256 _gasLimit, bytes memory _data) public payable {
         QKCConfigStorage storage $ = _getQKCConfigStorage();
         if ($.disableNativeDeposit && msg.value > 0) {
-            revert("native deposit/withdraw is disabled");
+            revert L2ToL1MessagePasser_NativeDepositDisabled();
         }
         bytes32 withdrawalHash = Hashing.hashWithdrawal(
             Types.WithdrawalTransaction({


### PR DESCRIPTION
Fixed semgrep findings about error handling:

```bash
semgrep scan --timeout=100 --config .semgrep/rules/ --error .
                                                            
    packages/contracts-bedrock/src/L1/OptimismPortal2.sol
   ❯❯❱ semgrep.rules.sol-style-error-format
          Error formatting is incorrect - must follow pattern
          ContractName_ErrorName with exactly one underscore 
                                                             
          219┆ error NativeDepositForbidden();
                                                                            
    packages/contracts-bedrock/src/L2/L2ToL1MessagePasser.sol
   ❯❯❱ semgrep.rules.sol-style-malformed-revert
          Revert statement style is malformed
                                             
          101┆ revert("native deposit/withdraw is disabled");
 ```
