### PR TITLE
CircleCI: fix go-lint about scalar multipliers

### DIFF
--- a/op-chain-ops/cmd/check-fjord/checks/checks.go
+++ b/op-chain-ops/cmd/check-fjord/checks/checks.go
@@ -28,12 +28,13 @@ import (
 )
 
 type CheckFjordConfig struct {
-	Log       log.Logger
-	L2        *ethclient.Client
-	Key       *ecdsa.PrivateKey
-	Addr      common.Address
-	GasUsed   uint64
-	L1GasUsed uint64
+	Log            log.Logger
+	L2             *ethclient.Client
+	Key            *ecdsa.PrivateKey
+	Addr           common.Address
+	GasUsed        uint64
+	L1GasUsed      uint64
+	OptimismConfig *params.OptimismConfig
 }
 
 func (ae *CheckFjordConfig) RecordGasUsed(rec *types.Receipt) {
@@ -191,7 +192,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 		return fmt.Errorf("calling GasPriceOracle.GetL1Fee: %w", err)
 	}
 
-	gethGPOFee, err := fjordL1Cost(gasPriceOracle, blockHash, uint64(types.FlzCompressLen(txUnsigned)+68))
+	gethGPOFee, err := fjordL1Cost(env.OptimismConfig, gasPriceOracle, blockHash, uint64(types.FlzCompressLen(txUnsigned)+68))
 	if err != nil {
 		return fmt.Errorf("calculating GPO fjordL1Cost: %w", err)
 	}
@@ -200,7 +201,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 	}
 	env.Log.Info("gethGPOFee matches gpoFee")
 
-	gethFee, err := fjordL1Cost(gasPriceOracle, blockHash, uint64(types.FlzCompressLen(txSigned)))
+	gethFee, err := fjordL1Cost(env.OptimismConfig, gasPriceOracle, blockHash, uint64(types.FlzCompressLen(txSigned)))
 	if err != nil {
 		return fmt.Errorf("calculating receipt fjordL1Cost: %w", err)
 	}
@@ -217,7 +218,7 @@ func sendTxAndCheckFees(ctx context.Context, env *CheckFjordConfig, to *common.A
 
 	txLenGPO := len(txUnsigned) + 68
 	flzUpperBound := uint64(txLenGPO + txLenGPO/255 + 16)
-	upperBoundCost, err := fjordL1Cost(gasPriceOracle, blockHash, flzUpperBound)
+	upperBoundCost, err := fjordL1Cost(env.OptimismConfig, gasPriceOracle, blockHash, flzUpperBound)
 	if err != nil {
 		return fmt.Errorf("failed to calculate fjordL1Cost: %w", err)
 	}
@@ -260,7 +261,7 @@ func CheckTxRandom(ctx context.Context, env *CheckFjordConfig) error {
 	return sendTxAndCheckFees(ctx, env, to, txData)
 }
 
-func fjordL1Cost(gasPriceOracle *bindings.GasPriceOracleCaller, block common.Hash, fastLzSize uint64) (*big.Int, error) {
+func fjordL1Cost(config *params.OptimismConfig, gasPriceOracle *bindings.GasPriceOracleCaller, block common.Hash, fastLzSize uint64) (*big.Int, error) {
 	opts := &bind.CallOpts{BlockHash: block}
 	baseFeeScalar, err := gasPriceOracle.BaseFeeScalar(opts)
 	if err != nil {
@@ -283,7 +284,10 @@ func fjordL1Cost(gasPriceOracle *bindings.GasPriceOracleCaller, block common.Has
 		l1BaseFee,
 		blobBaseFee,
 		new(big.Int).SetUint64(uint64(baseFeeScalar)),
-		new(big.Int).SetUint64(uint64(blobBaseFeeScalar)))
+		new(big.Int).SetUint64(uint64(blobBaseFeeScalar)),
+		new(big.Int).SetUint64(config.L1BaseFeeScalarMultiplier),
+		new(big.Int).SetUint64(config.L1BlobBaseFeeScalarMultiplier),
+	)
 
 	fee, _ := costFunc(types.RollupCostData{FastLzSize: fastLzSize})
 	return fee, nil

--- a/op-chain-ops/cmd/check-fjord/main.go
+++ b/op-chain-ops/cmd/check-fjord/main.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks"
 	op_service "github.com/ethereum-optimism/optimism/op-service"
 	"github.com/ethereum-optimism/optimism/op-service/cliapp"
 	"github.com/ethereum-optimism/optimism/op-service/ctxinterrupt"
+	"github.com/ethereum-optimism/optimism/op-service/dial"
 	oplog "github.com/ethereum-optimism/optimism/op-service/log"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -23,6 +25,12 @@ var (
 		Usage:   "L2 execution RPC endpoint",
 		EnvVars: op_service.PrefixEnvVar(prefix, "L2"),
 		Value:   "http://localhost:9545",
+	}
+	EndpointRollup = &cli.StringFlag{
+		Name:    "rollup",
+		Usage:   "L2 rollup-node RPC endpoint",
+		EnvVars: op_service.PrefixEnvVar(prefix, "ROLLUP"),
+		Value:   "http://localhost:5545",
 	}
 	AccountKey = &cli.StringFlag{
 		Name:    "account",
@@ -63,11 +71,20 @@ func makeCommandAction(fn CheckAction) func(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse test private key: %w", err)
 		}
+		rollupCl, err := dial.DialRollupClientWithTimeout(c.Context, time.Second*20, logger, c.String(EndpointRollup.Name))
+		if err != nil {
+			return fmt.Errorf("failed to dial rollup node RPC: %w", err)
+		}
+		rollupConf, err := rollupCl.RollupConfig(c.Context)
+		if err != nil {
+			return fmt.Errorf("rollup config retrieval failed: %w", err)
+		}
 		if err := fn(c.Context, &checks.CheckFjordConfig{
-			Log:  logger,
-			L2:   l2Cl,
-			Key:  key,
-			Addr: crypto.PubkeyToAddress(key.PublicKey),
+			Log:            logger,
+			L2:             l2Cl,
+			Key:            key,
+			Addr:           crypto.PubkeyToAddress(key.PublicKey),
+			OptimismConfig: rollupConf.ChainOpConfig,
 		}); err != nil {
 			return fmt.Errorf("command error: %w", err)
 		}

--- a/op-chain-ops/cmd/check-fjord/main.go
+++ b/op-chain-ops/cmd/check-fjord/main.go
@@ -44,6 +44,7 @@ type CheckAction func(ctx context.Context, env *checks.CheckFjordConfig) error
 func makeFlags() []cli.Flag {
 	flags := []cli.Flag{
 		EndpointL2,
+		EndpointRollup,
 		AccountKey,
 	}
 	return append(flags, oplog.CLIFlags(prefix)...)

--- a/op-e2e/actions/proofs/operator_fee_test.go
+++ b/op-e2e/actions/proofs/operator_fee_test.go
@@ -212,7 +212,7 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 			l1BlockInfo, err := derive.L1BlockInfoFromBytes(env.Sd.RollupCfg, unsafeHeader.Time, unsafeBlock.Transactions()[0].Data())
 			require.NoError(t, err)
 
-			daCost := fjordL1Cost(l1BlockInfo, types.NewRollupCostData(rlp, len(tx.BlobHashes())))
+			daCost := fjordL1Cost(env.Dp.DeployConfig, l1BlockInfo, types.NewRollupCostData(rlp, len(tx.BlobHashes())))
 			expectedFeePreIsthmus := nextBaseFee.Mul(nextBaseFee, big.NewInt(int64(params.TxGas)))
 			expectedFeePreIsthmus.Add(expectedFeePreIsthmus, daCost)
 
@@ -386,12 +386,15 @@ func Test_ProgramAction_OperatorFeeConsistency(gt *testing.T) {
 	matrix.Run(gt)
 }
 
-func fjordL1Cost(l1BlockInfo *derive.L1BlockInfo, rollupCostData types.RollupCostData) *big.Int {
+func fjordL1Cost(config *genesis.DeployConfig, l1BlockInfo *derive.L1BlockInfo, rollupCostData types.RollupCostData) *big.Int {
 	costFunc := types.NewL1CostFuncFjord(
 		l1BlockInfo.BaseFee,
 		l1BlockInfo.BlobBaseFee,
 		new(big.Int).SetUint64(uint64(l1BlockInfo.BaseFeeScalar)),
-		new(big.Int).SetUint64(uint64(l1BlockInfo.BlobBaseFeeScalar)))
+		new(big.Int).SetUint64(uint64(l1BlockInfo.BlobBaseFeeScalar)),
+		new(big.Int).SetUint64(config.L1BaseFeeScalarMultiplier),
+		new(big.Int).SetUint64(config.L1BlobBaseFeeScalarMultiplier),
+	)
 
 	fee, _ := costFunc(rollupCostData)
 	return fee

--- a/op-e2e/actions/upgrades/fjord_fork_test.go
+++ b/op-e2e/actions/upgrades/fjord_fork_test.go
@@ -138,11 +138,16 @@ func fjordL1Cost(t require.TestingT, gasPriceOracle *bindings.GasPriceOracleCall
 	blobBaseFee, err := gasPriceOracle.BlobBaseFee(nil)
 	require.NoError(t, err)
 
+	dp := e2eutils.MakeDeployParams(t, helpers.DefaultRollupTestParams())
+
 	costFunc := types.NewL1CostFuncFjord(
 		l1BaseFee,
 		blobBaseFee,
 		new(big.Int).SetUint64(uint64(baseFeeScalar)),
-		new(big.Int).SetUint64(uint64(blobBaseFeeScalar)))
+		new(big.Int).SetUint64(uint64(blobBaseFeeScalar)),
+		new(big.Int).SetUint64(dp.DeployConfig.L1BaseFeeScalarMultiplier),
+		new(big.Int).SetUint64(dp.DeployConfig.L1BlobBaseFeeScalarMultiplier),
+	)
 
 	fee, _ := costFunc(rollupCostData)
 	return fee


### PR DESCRIPTION
Failed tests:
```
golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
op-chain-ops/cmd/check-fjord/checks/checks.go:1: : # github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks
op-chain-ops/cmd/check-fjord/checks/checks.go:286:3: not enough arguments in call to types.NewL1CostFuncFjord
        have (*big.Int, *big.Int, *big.Int, *big.Int)
        want (*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int) (typecheck)
package checks
op-chain-ops/cmd/check-fjord/main.go:9:2: could not import github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks (-: # github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks
op-chain-ops/cmd/check-fjord/checks/checks.go:286:3: not enough arguments in call to types.NewL1CostFuncFjord
        have (*big.Int, *big.Int, *big.Int, *big.Int)
        want (*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int)) (typecheck)
        "github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks"
        ^
op-acceptance-tests/tests/fjord/check_scripts_test.go:11:14: could not import github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks (-: # github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks
op-chain-ops/cmd/check-fjord/checks/checks.go:286:3: not enough arguments in call to types.NewL1CostFuncFjord
        have (*big.Int, *big.Int, *big.Int, *big.Int)
        want (*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int)) (typecheck)
        fjordChecks "github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks"
                    ^
op-e2e/actions/proofs/fixtures.go:1: : # github.com/ethereum-optimism/optimism/op-e2e/actions/proofs [github.com/ethereum-optimism/optimism/op-e2e/actions/proofs.test]
op-e2e/actions/proofs/operator_fee_test.go:394:3: not enough arguments in call to types.NewL1CostFuncFjord
        have (*big.Int, *big.Int, *big.Int, *big.Int)
        want (*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int) (typecheck)
package proofs
op-e2e/actions/upgrades/dencun_fork_test.go:1: : # github.com/ethereum-optimism/optimism/op-e2e/actions/upgrades [github.com/ethereum-optimism/optimism/op-e2e/actions/upgrades.test]
op-e2e/actions/upgrades/fjord_fork_test.go:145:3: not enough arguments in call to types.NewL1CostFuncFjord
        have (*big.Int, *big.Int, *big.Int, *big.Int)
        want (*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int) (typecheck)
package upgrades
op-e2e/system/fjord/check_scripts_test.go:18:14: could not import github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks (-: # github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks
op-chain-ops/cmd/check-fjord/checks/checks.go:286:3: not enough arguments in call to types.NewL1CostFuncFjord
        have (*big.Int, *big.Int, *big.Int, *big.Int)
        want (*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int)) (typecheck)
        fjordChecks "github.com/ethereum-optimism/optimism/op-chain-ops/cmd/check-fjord/checks"
                    ^
make: *** [Makefile:24: lint-go] Error 1
```
Verified with:
```bash
golangci-lint run -E goimports,sqlclosecheck,bodyclose,asciicheck,misspell,errorlint --timeout 5m -e "errors.As" -e "errors.Is" ./...
# or 
make lint-go
```