### PR TITLE
CircleCI: fix specs of OptimismPortal2

### DIFF
--- a/packages/contracts-bedrock/test/universal/Specs.t.sol
+++ b/packages/contracts-bedrock/test/universal/Specs.t.sol
@@ -259,6 +259,9 @@ contract Specification_Test is CommonTest {
         _addSpec({ _name: "OptimismPortal2", _sel: _getSel("ethLockbox()") });
         _addSpec({ _name: "OptimismPortal2", _sel: _getSel("migrateLiquidity()") });
         _addSpec({ _name: "OptimismPortal2", _sel: _getSel("proxyAdminOwner()") });
+        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("setMinter(address)") });
+        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("mintTransaction(address,uint256)") });
+        _addSpec({ _name: "OptimismPortal2", _sel: _getSel("setNativeDeposit(bool)") });
 
         // ProxyAdminOwnedBase
         _addSpec({ _name: "ProxyAdminOwnedBase", _sel: _getSel("proxyAdminOwner()") });


### PR DESCRIPTION

Failing tests:
> Encountered 1 failing test in test/universal/Specs.t.sol:Specification_Test
[FAIL: Specification_Test: invalid number of ABI entries for OptimismPortal2: 36 != 33] test_contractAuth_works() (gas: 3509018)

Verified with:
```bash
cd packages/contracts-bedrock
forge test \
  --match-contract Specification_Test \
  --match-test contractAuth_works
```