### PR TITLE
make `mintTransaction` called via `CrossDomainMessenger`

### DIFF
--- a/packages/contracts-bedrock/interfaces/L1/IL1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IL1CrossDomainMessenger.sol
@@ -23,6 +23,14 @@ interface IL1CrossDomainMessenger is ICrossDomainMessenger, IProxyAdminOwnedBase
     function version() external view returns (string memory);
     function superchainConfig() external view returns (ISuperchainConfig);
     function upgrade(ISystemConfig _systemConfig) external;
+    function wrapForRelayMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit,
+        uint256 _value
+    )
+        external
+        returns (address otherMessenger, uint64 gasLimit, bytes memory data);
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IL1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IL1CrossDomainMessenger.sol
@@ -23,14 +23,13 @@ interface IL1CrossDomainMessenger is ICrossDomainMessenger, IProxyAdminOwnedBase
     function version() external view returns (string memory);
     function superchainConfig() external view returns (ISuperchainConfig);
     function upgrade(ISystemConfig _systemConfig) external;
-    function wrapForRelayMessage(
+    function sendMintMessage(
         address _target,
         bytes calldata _message,
-        uint32 _minGasLimit,
-        uint256 _value
-    )
-        external
-        returns (address otherMessenger, uint64 gasLimit, bytes memory data);
+        uint256 _mintValue,
+        uint32 _minGasLimit
+    ) external;
+    function setMinter(address _minter) external;
 
     function __constructor__() external;
 }

--- a/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
+++ b/packages/contracts-bedrock/interfaces/L1/IOptimismPortal2.sol
@@ -125,8 +125,7 @@ interface IOptimismPortal2 is IProxyAdminOwnedBase {
     function version() external pure returns (string memory);
     function migrateLiquidity() external;
 
-    function setMinter(address _minter) external;
-    function mintTransaction(address _to, uint256 _value) external;
+    function mintTransaction(address _to, uint256 _mintValue, uint64 _gasLimit, bytes memory _data) external;
     function setNativeDeposit(bool _disable) external;
 
     function __constructor__(uint256 _proofMaturityDelaySeconds) external;

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -21,6 +21,9 @@ import { IOptimismPortal2 as IOptimismPortal } from "interfaces/L1/IOptimismPort
 ///         for sending and receiving data on the L1 side. Users are encouraged to use this
 ///         interface instead of interacting with lower-level contracts directly.
 contract L1CrossDomainMessenger is CrossDomainMessenger, ProxyAdminOwnedBase, ReinitializableBase, ISemver {
+    /// @notice Thrown when the caller is not the minter.
+    error L1CrossDomainMessenger_NotMinter();
+
     /// @custom:legacy
     /// @custom:spacer superchainConfig
     /// @notice Spacer taking up the legacy `superchainConfig` slot.
@@ -41,6 +44,9 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ProxyAdminOwnedBase, Re
 
     /// @notice Contract of the SystemConfig.
     ISystemConfig public systemConfig;
+
+    /// @notice Emitted when a minter is set.
+    event MinterSet(address indexed minter);
 
     /// @notice Constructs the L1CrossDomainMessenger contract.
     constructor() ReinitializableBase(2) {
@@ -89,25 +95,59 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ProxyAdminOwnedBase, Re
         return portal;
     }
 
-    /// @notice Returns the required parameters for wrapping a call with the relayMessage function on L2.
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.L1CrossDomainMessenger.QKCConfigStorage")) - 1)) &
+    // ~bytes32(uint256(0xff))
+    bytes32 private constant _QKC_CONFIG_STORAGE_LOCATION =
+        0x21f30a216d738aeb55799dae7148f127e3b8f70b0224a5edb846c108cd573c00;
+    /// @custom:storage-location erc7201:openzeppelin.storage.L1CrossDomainMessenger.QKCConfigStorage
+
+    struct QKCConfigStorage {
+        /// @notice The minter for migrating existing L1 token to L2 native token.
+        address minter;
+    }
+
+    function _getQKCConfigStorage() private pure returns (QKCConfigStorage storage $) {
+        assembly {
+            $.slot := _QKC_CONFIG_STORAGE_LOCATION
+        }
+    }
+
+    /// @notice Add a minter to the L1CrossDomainMessenger contract. To disable, set an empty value.
+    function setMinter(address _minter) external {
+        _assertOnlyProxyAdminOrProxyAdminOwner();
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        $.minter = _minter;
+        emit MinterSet(_minter);
+    }
+
+    /// @notice Triggers a QKC mint message via the relayMessage function on L2. Can only be called by the minter.
+    /// @dev    This function can only be called by the minter.
     /// @param _target      Target contract or wallet address.
     /// @param _message     Message to trigger the target address with.
+    /// @param _mintValue   Value to mint.
     /// @param _minGasLimit Minimum gas limit that the message can be executed with.
-    /// @param _value       Value to send with the message.
-    function wrapForRelayMessage(
+    function sendMintMessage(
         address _target,
         bytes calldata _message,
-        uint32 _minGasLimit,
-        uint256 _value
+        uint256 _mintValue,
+        uint32 _minGasLimit
     )
         external
-        returns (address otherMessenger_, uint64 gasLimit, bytes memory data)
     {
-        otherMessenger_ = otherMessenger;
-        gasLimit = baseGas(_message, _minGasLimit);
-        data = abi.encodeWithSelector(
-            this.relayMessage.selector, messageNonce(), msg.sender, _target, _value, _minGasLimit, _message
-        );
+        QKCConfigStorage storage $ = _getQKCConfigStorage();
+        if (msg.sender != $.minter) {
+            revert L1CrossDomainMessenger_NotMinter();
+        }
+
+        portal.mintTransaction({
+            _to: address(otherMessenger),
+            _value: _mintValue,
+            _gasLimit: baseGas(_message, _minGasLimit),
+            _data: abi.encodeWithSelector(
+                this.relayMessage.selector, messageNonce(), msg.sender, _target, _mintValue, _minGasLimit, _message
+            )
+        });
+
         unchecked {
             ++msgNonce;
         }

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -89,6 +89,30 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ProxyAdminOwnedBase, Re
         return portal;
     }
 
+    /// @notice Returns the required parameters for wrapping a call with the relayMessage function on L2.
+    /// @param _target      Target contract or wallet address.
+    /// @param _message     Message to trigger the target address with.
+    /// @param _minGasLimit Minimum gas limit that the message can be executed with.
+    /// @param _value       Value to send with the message.
+    function wrapForRelayMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _minGasLimit,
+        uint256 _value
+    )
+        external
+        returns (address otherMessenger_, uint64 gasLimit, bytes memory data)
+    {
+        otherMessenger_ = otherMessenger;
+        gasLimit = baseGas(_message, _minGasLimit);
+        data = abi.encodeWithSelector(
+            this.relayMessage.selector, messageNonce(), msg.sender, _target, _value, _minGasLimit, _message
+        );
+        unchecked {
+            ++msgNonce;
+        }
+    }
+
     /// @inheritdoc CrossDomainMessenger
     function _sendMessage(address _to, uint64 _gasLimit, uint256 _value, bytes memory _data) internal override {
         portal.depositTransaction{ value: _value }({

--- a/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
+++ b/packages/contracts-bedrock/src/L1/L1CrossDomainMessenger.sol
@@ -141,7 +141,7 @@ contract L1CrossDomainMessenger is CrossDomainMessenger, ProxyAdminOwnedBase, Re
 
         portal.mintTransaction({
             _to: address(otherMessenger),
-            _value: _mintValue,
+            _mintValue: _mintValue,
             _gasLimit: baseGas(_message, _minGasLimit),
             _data: abi.encodeWithSelector(
                 this.relayMessage.selector, messageNonce(), msg.sender, _target, _mintValue, _minGasLimit, _message

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -22,6 +22,7 @@ import { GameStatus, GameType } from "src/dispute/lib/Types.sol";
 import { ISemver } from "interfaces/universal/ISemver.sol";
 import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
 import { IResourceMetering } from "interfaces/L1/IResourceMetering.sol";
+import { IL1CrossDomainMessenger } from "interfaces/L1/IL1CrossDomainMessenger.sol";
 import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
 import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
 import { IL2ToL1MessagePasser } from "interfaces/L2/IL2ToL1MessagePasser.sol";
@@ -771,7 +772,10 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     }
 
     /// @notice Mint a specific amount of L2 native token to an address.
-    function mintTransaction(address _to, uint256 _value) external metered(RECEIVE_DEFAULT_GAS_LIMIT) {
+    function mintTransaction(address _to, uint256 _value, uint32 _minGasLimit) external {
+        // Record initial gas amount so we can refund for it later.
+        uint256 initialGas = gasleft();
+
         QKCConfigStorage storage $ = _getQKCConfigStorage();
         if (msg.sender != $.minter) {
             revert OptimismPortal_Unauthorized();
@@ -780,14 +784,30 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         if (_to == address(0)) {
             revert OptimismPortal_BadTarget();
         }
+
+        address l1CrossDomainMessenger = systemConfig.l1CrossDomainMessenger();
+        (address otherMessenger, uint64 gasLimit, bytes memory data) =
+            IL1CrossDomainMessenger(l1CrossDomainMessenger).wrapForRelayMessage(_to, bytes(""), _minGasLimit, _value);
+
         // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
         // We use opaque data so that we can update the TransactionDeposited event in the future
         // without breaking the current interface.
-        bytes memory opaqueData = abi.encodePacked(_value, _value, RECEIVE_DEFAULT_GAS_LIMIT, false, bytes(""));
+        bytes memory opaqueData = abi.encodePacked(_value, _value, gasLimit, false, data);
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
-        emit TransactionDeposited(Constants.QKC_DEPOSITOR_ACCOUNT, _to, DEPOSIT_VERSION, opaqueData);
+        emit TransactionDeposited(
+            /**
+             * alias is needed to satisfy _isOtherMessenger() on L2 *
+             */
+            AddressAliasHelper.applyL1ToL2Alias(l1CrossDomainMessenger),
+            otherMessenger,
+            DEPOSIT_VERSION,
+            opaqueData
+        );
+
+        // Run the metering function.
+        _metered(gasLimit, initialGas);
     }
 
     /// @notice set native deposit flag. Pass true to disable.

--- a/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
+++ b/packages/contracts-bedrock/src/L1/OptimismPortal2.sol
@@ -138,8 +138,7 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
     /// @custom:storage-location erc7201:openzeppelin.storage.OptimismPortal2.QKCConfigStorage
 
     struct QKCConfigStorage {
-        /// @notice The minter for migrating existing L1 token to L2 native token.
-        address minter;
+        address spacer_for_minter;// should not be used again
         bool disableNativeDeposit;
     }
 
@@ -192,8 +191,6 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         IAnchorStateRegistry newAnchorStateRegistry
     );
 
-    /// @notice Emitted when a minter is set.
-    event MinterSet(address indexed minter);
     /// @notice Emitted when native deposit is disabled.
     event NativeDepositDisabled();
     /// @notice Emitted when native deposit is enabled.
@@ -761,53 +758,39 @@ contract OptimismPortal2 is Initializable, ResourceMetering, ReinitializableBase
         }
     }
 
-    /// @notice Add a minter to the OptimismPortal contract. To disable, set an empty value.
-    function setMinter(address _minter) external {
-        if (msg.sender != proxyAdminOwner()) {
-            revert OptimismPortal_Unauthorized();
-        }
-        QKCConfigStorage storage $ = _getQKCConfigStorage();
-        $.minter = _minter;
-        emit MinterSet(_minter);
-    }
-
     /// @notice Mint a specific amount of L2 native token to an address.
-    function mintTransaction(address _to, uint256 _value, uint32 _minGasLimit) external {
-        // Record initial gas amount so we can refund for it later.
-        uint256 initialGas = gasleft();
-
-        QKCConfigStorage storage $ = _getQKCConfigStorage();
-        if (msg.sender != $.minter) {
+    /// @dev    This function is only callable by L1CrossDomainMessenger.
+    function mintTransaction(
+        address _to,
+        uint256 _mintValue,
+        uint64 _gasLimit,
+        bytes memory _data
+    )
+        external
+        metered(_gasLimit)
+    {
+        // Can only be called by L1CrossDomainMessenger
+        address l1CrossDomainMessenger = systemConfig.l1CrossDomainMessenger();
+        if (msg.sender != l1CrossDomainMessenger) {
             revert OptimismPortal_Unauthorized();
         }
 
-        if (_to == address(0)) {
-            revert OptimismPortal_BadTarget();
+        // Prevent depositing transactions that have too small of a gas limit. Users should pay
+        // more for more resource usage.
+        if (_gasLimit < minimumGasLimit(uint64(_data.length))) {
+            revert OptimismPortal_GasLimitTooLow();
         }
 
-        address l1CrossDomainMessenger = systemConfig.l1CrossDomainMessenger();
-        (address otherMessenger, uint64 gasLimit, bytes memory data) =
-            IL1CrossDomainMessenger(l1CrossDomainMessenger).wrapForRelayMessage(_to, bytes(""), _minGasLimit, _value);
+        address from = AddressAliasHelper.applyL1ToL2Alias(msg.sender);
 
         // Compute the opaque data that will be emitted as part of the TransactionDeposited event.
         // We use opaque data so that we can update the TransactionDeposited event in the future
         // without breaking the current interface.
-        bytes memory opaqueData = abi.encodePacked(_value, _value, gasLimit, false, data);
+        bytes memory opaqueData = abi.encodePacked(_mintValue, _mintValue, _gasLimit, false, _data);
 
         // Emit a TransactionDeposited event so that the rollup node can derive a deposit
         // transaction for this deposit.
-        emit TransactionDeposited(
-            /**
-             * alias is needed to satisfy _isOtherMessenger() on L2 *
-             */
-            AddressAliasHelper.applyL1ToL2Alias(l1CrossDomainMessenger),
-            otherMessenger,
-            DEPOSIT_VERSION,
-            opaqueData
-        );
-
-        // Run the metering function.
-        _metered(gasLimit, initialGas);
+        emit TransactionDeposited(from, _to, DEPOSIT_VERSION, opaqueData);
     }
 
     /// @notice set native deposit flag. Pass true to disable.


### PR DESCRIPTION
This PR makes the deposit tx corresponding to `mintTransaction` triggered via `L2CrossDomainMessenger.relayMessage` so that if the execution failed on L2, it can be retried later.