### PR TITLE
fix deadlock for gamma

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -39,6 +39,7 @@ import (
 )
 
 var ErrAlreadyClosed = errors.New("node is already closed")
+var ErrIsClosing = errors.New("node is closing")
 
 type closableSafeDB interface {
 	rollup.SafeHeadListener
@@ -89,7 +90,8 @@ type OpNode struct {
 	// Indicates when it's safe to close data sources used by the runtimeConfig bg loader
 	runtimeConfigReloaderDone chan struct{}
 
-	closed atomic.Bool
+	closed  atomic.Bool
+	closing atomic.Bool
 
 	// cancels execution prematurely, e.g. to halt. This may be nil.
 	cancel context.CancelCauseFunc
@@ -569,6 +571,9 @@ func (n *OpNode) onEvent(ev event.Event) bool {
 }
 
 func (n *OpNode) OnNewL1Head(ctx context.Context, sig eth.L1BlockRef) {
+	if n.closing.Load() {
+		return
+	}
 	n.tracer.OnNewL1Head(ctx, sig)
 
 	if n.l2Driver == nil {
@@ -583,6 +588,9 @@ func (n *OpNode) OnNewL1Head(ctx context.Context, sig eth.L1BlockRef) {
 }
 
 func (n *OpNode) OnNewL1Safe(ctx context.Context, sig eth.L1BlockRef) {
+	if n.closing.Load() {
+		return
+	}
 	if n.l2Driver == nil {
 		return
 	}
@@ -595,6 +603,9 @@ func (n *OpNode) OnNewL1Safe(ctx context.Context, sig eth.L1BlockRef) {
 }
 
 func (n *OpNode) OnNewL1Finalized(ctx context.Context, sig eth.L1BlockRef) {
+	if n.closing.Load() {
+		return
+	}
 	if n.l2Driver == nil {
 		return
 	}
@@ -607,6 +618,9 @@ func (n *OpNode) OnNewL1Finalized(ctx context.Context, sig eth.L1BlockRef) {
 }
 
 func (n *OpNode) PublishL2Payload(ctx context.Context, envelope *eth.ExecutionPayloadEnvelope) error {
+	if n.closing.Load() {
+		return ErrIsClosing
+	}
 	n.tracer.OnPublishL2Payload(ctx, envelope)
 
 	// publish to p2p, if we are running p2p at all
@@ -622,6 +636,9 @@ func (n *OpNode) PublishL2Payload(ctx context.Context, envelope *eth.ExecutionPa
 }
 
 func (n *OpNode) OnUnsafeL2Payload(ctx context.Context, from peer.ID, envelope *eth.ExecutionPayloadEnvelope) error {
+	if n.closing.Load() {
+		return ErrIsClosing
+	}
 	// ignore if it's from ourselves
 	if p2pNode := n.getP2PNodeIfEnabled(); p2pNode != nil && from == p2pNode.Host().ID() {
 		return nil
@@ -678,6 +695,7 @@ func (n *OpNode) Stop(ctx context.Context) error {
 	if n.closed.Load() {
 		return ErrAlreadyClosed
 	}
+	n.closing.Store(true)
 
 	var result *multierror.Error
 


### PR DESCRIPTION
Currently when node is deriving, ctrl-c often doesn't work.

It's due to the deadlock when `OpNode.Stop` is being called.

Call stack to trigger deadlock:

```
#	0x1694ef2	sync.(*Mutex).Lock+0x92									/root/.local/share/mise/installs/go/1.22.7/src/sync/mutex.go:90
#	0x1694ec2	github.com/ethereum-optimism/optimism/op-node/node.(*OpNode).getP2PNodeIfEnabled+0x62	/root/xu/gamma/optimism/op-node/node/node.go:842
#	0x16934a6	github.com/ethereum-optimism/optimism/op-node/node.(*OpNode).OnUnsafeL2Payload+0x66	/root/xu/gamma/optimism/op-node/node/node.go:626
#	0x16172a2	github.com/ethereum-optimism/optimism/op-node/p2p.(*SyncClient).promote+0x1e2		/root/xu/gamma/optimism/op-node/p2p/sync.go:511
#	0x1617aa7	github.com/ethereum-optimism/optimism/op-node/p2p.(*SyncClient).onResult+0x327		/root/xu/gamma/optimism/op-node/p2p/sync.go:548
#	0x16160fd	github.com/ethereum-optimism/optimism/op-node/p2p.(*SyncClient).mainLoop+0x23d		/root/xu/gamma/optimism/op-node/p2p/sync.go:407
```

This issue is gone in latest upstream develop branch due to refactor.