### PR TITLE
boost p2p ratelimit

### DIFF
--- a/op-node/node/node.go
+++ b/op-node/node/node.go
@@ -537,7 +537,7 @@ func (n *OpNode) initP2P(cfg *config.Config) (err error) {
 	if n.p2pEnabled() {
 		em := n.eventSys.Register("p2p-block-receiver", nil)
 		rec := p2p.NewBlockReceiver(n.log, em, n.metrics)
-		n.p2pNode, err = p2p.NewNodeP2P(n.resourcesCtx, &cfg.Rollup, n.log, cfg.P2P, rec, n.l2Source, n.runCfg, n.metrics, false)
+		n.p2pNode, err = p2p.NewNodeP2P(n.resourcesCtx, &cfg.Rollup, n.log, cfg.P2P, rec, n.l2Source, n.runCfg, n.metrics, false, cfg.Driver.SequencerEnabled)
 		if err != nil {
 			return
 		}

--- a/op-node/p2p/host_test.go
+++ b/op-node/p2p/host_test.go
@@ -120,7 +120,7 @@ func TestP2PFull(t *testing.T) {
 	runCfgB := &testutils.MockRuntimeConfig{P2PSeqAddress: common.Address{0x42}}
 
 	logA := testlog.Logger(t, log.LevelError).New("host", "A")
-	nodeA, err := NewNodeP2P(context.Background(), &rollup.Config{}, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, false)
+	nodeA, err := NewNodeP2P(context.Background(), &rollup.Config{}, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, false, false)
 	require.NoError(t, err)
 	defer nodeA.Close()
 
@@ -149,7 +149,7 @@ func TestP2PFull(t *testing.T) {
 
 	logB := testlog.Logger(t, log.LevelError).New("host", "B")
 
-	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, false)
+	nodeB, err := NewNodeP2P(context.Background(), &rollup.Config{}, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, false, false)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
@@ -321,7 +321,7 @@ func TestDiscovery(t *testing.T) {
 	resourcesCtx, resourcesCancel := context.WithCancel(context.Background())
 	defer resourcesCancel()
 
-	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, false)
+	nodeA, err := NewNodeP2P(context.Background(), rollupCfg, logA, &confA, &mockGossipIn{}, nil, runCfgA, metrics.NoopMetrics, false, false)
 	require.NoError(t, err)
 	defer nodeA.Close()
 	hostA := nodeA.Host()
@@ -336,7 +336,7 @@ func TestDiscovery(t *testing.T) {
 	confB.DiscoveryDB = discDBC
 
 	// Start B
-	nodeB, err := NewNodeP2P(context.Background(), rollupCfg, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, false)
+	nodeB, err := NewNodeP2P(context.Background(), rollupCfg, logB, &confB, &mockGossipIn{}, nil, runCfgB, metrics.NoopMetrics, false, false)
 	require.NoError(t, err)
 	defer nodeB.Close()
 	hostB := nodeB.Host()
@@ -351,7 +351,7 @@ func TestDiscovery(t *testing.T) {
 		}})
 
 	// Start C
-	nodeC, err := NewNodeP2P(context.Background(), rollupCfg, logC, &confC, &mockGossipIn{}, nil, runCfgC, metrics.NoopMetrics, false)
+	nodeC, err := NewNodeP2P(context.Background(), rollupCfg, logC, &confC, &mockGossipIn{}, nil, runCfgC, metrics.NoopMetrics, false, false)
 	require.NoError(t, err)
 	defer nodeC.Close()
 	hostC := nodeC.Host()

--- a/op-node/p2p/node.go
+++ b/op-node/p2p/node.go
@@ -62,6 +62,7 @@ func NewNodeP2P(
 	runCfg GossipRuntimeConfig,
 	metrics metrics.Metricer,
 	elSyncEnabled bool,
+	sequencerEnabled bool,
 ) (*NodeP2P, error) {
 	if setup == nil {
 		return nil, errors.New("p2p node cannot be created without setup")
@@ -70,7 +71,7 @@ func NewNodeP2P(
 		return nil, errors.New("SetupP2P.Disabled is true")
 	}
 	var n NodeP2P
-	if err := n.init(resourcesCtx, rollupCfg, log, setup, gossipIn, l2Chain, runCfg, metrics, elSyncEnabled); err != nil {
+	if err := n.init(resourcesCtx, rollupCfg, log, setup, gossipIn, l2Chain, runCfg, metrics, elSyncEnabled, sequencerEnabled); err != nil {
 		closeErr := n.Close()
 		if closeErr != nil {
 			log.Error("failed to close p2p after starting with err", "closeErr", closeErr, "err", err)
@@ -95,6 +96,7 @@ func (n *NodeP2P) init(
 	runCfg GossipRuntimeConfig,
 	metrics metrics.Metricer,
 	elSyncEnabled bool,
+	sequencerEnabled bool,
 ) error {
 	bwc := p2pmetrics.NewBandwidthCounter()
 
@@ -150,7 +152,7 @@ func (n *NodeP2P) init(
 			n.syncCl.AddPeer(peerID)
 		}
 		if l2Chain != nil { // Only enable serving side of req-resp sync if we have a data-source, to make minimal P2P testing easy
-			n.syncSrv = NewReqRespServer(rollupCfg, l2Chain, metrics)
+			n.syncSrv = NewReqRespServer(rollupCfg, l2Chain, metrics, sequencerEnabled)
 			// register the sync protocol with libp2p host
 			payloadByNumber := MakeStreamHandler(resourcesCtx, log.New("serve", "payloads_by_number"), n.syncSrv.HandleSyncRequest)
 			n.host.SetStreamHandler(PayloadByNumberProtocolID(rollupCfg.L2ChainID), payloadByNumber)

--- a/op-node/p2p/sync.go
+++ b/op-node/p2p/sync.go
@@ -59,6 +59,7 @@ const (
 	// and eventually kick the peer based on degraded scoring if it's really not serving us well.
 	// TODO: Use a backoff rather than this mechanism.
 	clientErrRateCost = peerServerBlocksBurst
+	qkcRateLimitBoost = 30
 )
 
 const (
@@ -279,6 +280,7 @@ type SyncClient struct {
 
 	extra               ExtraHostFeatures
 	syncOnlyReqToStatic bool
+	sequencerEnabled    bool
 }
 
 func NewSyncClient(log log.Logger, cfg *rollup.Config, host HostNewStream, rcv receivePayloadFn, metrics SyncClientMetrics, appScorer SyncPeerScorer) *SyncClient {
@@ -307,6 +309,7 @@ func NewSyncClient(log log.Logger, cfg *rollup.Config, host HostNewStream, rcv r
 	if extra, ok := host.(ExtraHostFeatures); ok && extra.SyncOnlyReqToStatic() {
 		c.extra = extra
 		c.syncOnlyReqToStatic = true
+		c.globalRL = rate.NewLimiter(globalServerBlocksRateLimit*qkcRateLimitBoost, globalServerBlocksBurst*qkcRateLimitBoost)
 	}
 
 	// never errors with positive LRU cache size
@@ -565,6 +568,9 @@ func (s *SyncClient) peerLoop(ctx context.Context, id peer.ID) {
 	// Implement the same rate limits as the server does per-peer,
 	// so we don't be too aggressive to the server.
 	rl := rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst)
+	if s.syncOnlyReqToStatic {
+		rl = rate.NewLimiter(peerServerBlocksRateLimit*qkcRateLimitBoost, peerServerBlocksBurst*qkcRateLimitBoost)
+	}
 
 	// if onlyReqToStatic is on, ensure that only static peers are dealing with the request
 	peerRequests := s.peerRequests
@@ -802,14 +808,19 @@ type ReqRespServer struct {
 	peerStatsLock  sync.Mutex
 
 	globalRequestsRL *rate.Limiter
+
+	sequencerEnabled bool
 }
 
-func NewReqRespServer(cfg *rollup.Config, l2 L2Chain, metrics ReqRespServerMetrics) *ReqRespServer {
+func NewReqRespServer(cfg *rollup.Config, l2 L2Chain, metrics ReqRespServerMetrics, sequencerEnabled bool) *ReqRespServer {
 	// We should never allow over 1000 different peers to churn through quickly,
 	// so it's fine to prune rate-limit details past this.
 
 	peerRateLimits, _ := simplelru.NewLRU[peer.ID, *peerStat](1000, nil)
 	globalRequestsRL := rate.NewLimiter(globalServerBlocksRateLimit, globalServerBlocksBurst)
+	if sequencerEnabled {
+		globalRequestsRL = rate.NewLimiter(globalServerBlocksRateLimit*qkcRateLimitBoost, globalServerBlocksBurst*qkcRateLimitBoost)
+	}
 
 	return &ReqRespServer{
 		cfg:              cfg,
@@ -817,6 +828,7 @@ func NewReqRespServer(cfg *rollup.Config, l2 L2Chain, metrics ReqRespServerMetri
 		metrics:          metrics,
 		peerRateLimits:   peerRateLimits,
 		globalRequestsRL: globalRequestsRL,
+		sequencerEnabled: sequencerEnabled,
 	}
 }
 
@@ -871,6 +883,9 @@ func (srv *ReqRespServer) handleSyncRequest(ctx context.Context, stream network.
 	if ps == nil {
 		ps = &peerStat{
 			Requests: rate.NewLimiter(peerServerBlocksRateLimit, peerServerBlocksBurst),
+		}
+		if srv.sequencerEnabled {
+			ps.Requests = rate.NewLimiter(peerServerBlocksRateLimit*qkcRateLimitBoost, peerServerBlocksBurst*qkcRateLimitBoost)
 		}
 		srv.peerRateLimits.Add(peerId, ps)
 		ps.Requests.Reserve() // count the hit, but make it delay the next request rather than immediately waiting


### PR DESCRIPTION
<img width="1298" height="448" alt="image" src="https://github.com/user-attachments/assets/49ba337c-0390-4b06-a0e5-4644414d6b6d" />

This pr tries to fix the slow p2p range request found in gamma testnet.

Does 2 things:
1. for sequencer(server side), the rate limit is boosted by 30x, since we can whitelist allowed IPs.(maybe we can disable rate limit for sequencer if still not enough?)
2. for sync client(client side), the rate limit is boosted by 30x if `syncOnlyReqToStatic` is true

