### PR TITLE
Fix "contracts-bedrock-tests" ci error

### DIFF
--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -8,7 +8,7 @@ import { Fork } from "scripts/libraries/Config.sol";
 //          This excludes the preinstalls (non-protocol contracts).
 library Predeploys {
     /// @notice Number of predeploy-namespace addresses reserved for protocol usage.
-    uint256 internal constant PREDEPLOY_COUNT = 2048;
+    uint256 internal constant PREDEPLOY_COUNT = 4096;
 
     /// @custom:legacy
     /// @notice Address of the LegacyMessagePasser predeploy. Deprecate. Use the updated

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -8,7 +8,7 @@ import { Fork } from "scripts/libraries/Config.sol";
 //          This excludes the preinstalls (non-protocol contracts).
 library Predeploys {
     /// @notice Number of predeploy-namespace addresses reserved for protocol usage.
-    uint256 internal constant PREDEPLOY_COUNT = 4096;
+    uint256 internal constant PREDEPLOY_COUNT = 2048;
 
     /// @custom:legacy
     /// @notice Address of the LegacyMessagePasser predeploy. Deprecate. Use the updated

--- a/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
+++ b/packages/contracts-bedrock/test/scripts/L2Genesis.t.sol
@@ -129,7 +129,7 @@ contract L2Genesis_Run_Test is L2Genesis_TestInit {
             deployCrossL2Inbox: true,
             enableGovernance: true,
             fundDevAccounts: true,
-            deploySoulGasToken: false,
+            deploySoulGasToken: true,
             isSoulBackedByNative: false
         });
         genesis.run(input);


### PR DESCRIPTION
fix https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/44/workflows/2c095aa3-7729-453f-9491-9a1b0ce1a950/jobs/992/steps 

The number of **PREDEPLOY_COUNT** was changed from 2048 to 4096, and a **SOUL_GAS_TOKEN** was added. However, the **deploySoulGasToken** is false, causing the contract implementation not to be deployed. As a result, the impl returned by 
```
address impl = Predeploys.predeployToCodeNamespace(addr);
assertGt(impl.code.length, 0); 
``` 
was empty.