### PR TITLE
Fix svm installation on CI by updating Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default_docker_image:
     type: string
-    default: cimg/base:2025.08
+    default: cimg/base:2024.01
   base_image:
     type: string
     default: default
@@ -105,10 +105,19 @@ commands:
               chown -R "$user:$user" ~/.cache
               echo "Created Mise cache dir."
             fi
+      - run:
+          name: Detect glibc version
+          command: |
+            if ldd --version >/dev/null 2>&1; then
+              ldd --version | head -n1 | awk '{print $NF}' > .glibc-version
+            else
+              echo "musl" > .glibc-version
+            fi
+            echo "Detected glibc/musl version: $(cat .glibc-version)"
       - restore_cache:
           name: "Restore mise cache"
           keys:
-            - "mise-v5-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+            - "mise-v5-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}-{{ checksum \".glibc-version\" }}"
       - run:
           name: "Install mise"
           command: |
@@ -127,13 +136,13 @@ commands:
             mise install -v -y
       - save_cache:
           name: "Save mise cache"
-          key: "mise-v5-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}"
+          key: "mise-v5-cache-{{ .Environment.CACHE_VERSION }}-{{ checksum \".executor-user\" }}-{{ checksum \"mise.toml\" }}-{{ checksum \".glibc-version\" }}"
           paths:
             - << parameters.mise_data_dir >>
       - run:
-          name: "Delete executor file"
+          name: "Clean up temp files"
           command: |
-            rm -f .executor-user
+            rm -f .executor-user .glibc-version
 
   gcp-oidc-authenticate:
     description: "Authenticate with GCP using a CircleCI OIDC token."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default_docker_image:
     type: string
-    default: cimg/base:2024.01
+    default: cimg/base:2024.04
   base_image:
     type: string
     default: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,9 @@ commands:
       - run:
           name: Detect glibc version
           command: |
-            if ldd --version >/dev/null 2>&1; then
-              ldd --version | head -n1 | awk '{print $NF}' > .glibc-version
+            if command -v ldd >/dev/null 2>&1; then
+              # Use process substitution to avoid SIGPIPE in pipefail
+              awk 'NR==1 {print $NF}' <(ldd --version) > .glibc-version
             else
               echo "musl" > .glibc-version
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   default_docker_image:
     type: string
-    default: cimg/base:2024.04
+    default: cimg/base:2025.08
   base_image:
     type: string
     default: default


### PR DESCRIPTION
Our CI uses two different base images. Since both share the same cache key, svm built on a higher-glibc image was restored on a lower-glibc image, causing runtime failures.

Solution
Introduce cache isolation by differentiating cache keys per base image (or enforce a single base image across jobs).

CI:

> https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/45/workflows/25af55be-d0c4-401d-9eea-9cafe853743d/jobs/1073

> https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/45/workflows/25af55be-d0c4-401d-9eea-9cafe853743d/jobs/1055

> https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/45/workflows/25af55be-d0c4-401d-9eea-9cafe853743d/jobs/1053

> https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/45/workflows/25af55be-d0c4-401d-9eea-9cafe853743d/jobs/1033