### PR TITLE
Fix missing output in "check-generated-mocks-op-node" step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1633,7 +1633,9 @@ jobs:
           patterns: op-node
       - run:
           name: check-generated-mocks
-          command: make generate-mocks-op-node && git diff --exit-code
+          command: |
+            make generate-mocks-op-node
+            git diff --exit-code
 
   check-generated-mocks-op-service:
     machine: true


### PR DESCRIPTION
The [CI](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/45/workflows/25af55be-d0c4-401d-9eea-9cafe853743d/jobs/1027) `check-generated-mocks` step was timing out due to missing output. The issue was caused by the git diff `--exit-code` command being run with an incorrect `--ignore-submodules `flag concatenation, which resulted in no output being printed.

This PR fixes the command so that git diff always produces output when changes exist, preventing CI from hanging due to inactivity.

```
#!/bin/bash -eo pipefail
make generate-mocks-op-node && git diff --ignore-submodules--exit-code
```
Lost a space