### PR TITLE
CircleCI: fix timeout

### DIFF
--- a/op-e2e/actions/helpers/tx_helper.go
+++ b/op-e2e/actions/helpers/tx_helper.go
@@ -25,7 +25,7 @@ func firstValidTx(
 	var txs []*types.Transaction
 	var q []*types.Transaction
 	// Wait for the tx to be in the pending tx queue
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 	err := wait.For(ctx, time.Second, func() (bool, error) {
 		i = pendingIndices(from)


### PR DESCRIPTION
Fix timeout issues such as:

```
=== RUN   TestCrossLayerUser_Default/fork_regolith/at_genesis
=== PAUSE TestCrossLayerUser_Default/fork_regolith/at_genesis
=== CONT  TestCrossLayerUser_Default/fork_regolith/at_genesis
    testlog.go:148: writing test log to /var/lib/circleci-runner/workdir/tmp/testlogs/TestCrossLayerUserDefaultforkregolithatgenesis-3614552.log
    tx_helper.go:45: 
                Error Trace:    /var/lib/circleci-runner/workdir/op-e2e/actions/helpers/tx_helper.go:45
                                                        /var/lib/circleci-runner/workdir/op-e2e/actions/helpers/l2_engine.go:232
                                                        /var/lib/circleci-runner/workdir/op-e2e/actions/helpers/user_test.go:284
                                                        /var/lib/circleci-runner/workdir/op-e2e/actions/helpers/user_test.go:112
                Error:          Received unexpected error:
                                write pipe: i/o timeout
                Test:           TestCrossLayerUser_Default/fork_regolith/at_genesis
                Messages:       no pending txs from 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65, and have 0 unprocessable queued txs from this account: %!w(*net.OpError=&{write pipe <nil> <nil> 0x487a820})
```

These are not reproducible locally and are flaky on the server.