### PR TITLE
CircleCI: fix commit change in check-generated-mocks-op-node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1633,7 +1633,7 @@ jobs:
           patterns: op-node
       - run:
           name: check-generated-mocks
-          command: make generate-mocks-op-node && git diff --exit-code
+          command: make generate-mocks-op-node && git diff --ignore-submodules --exit-code
 
   check-generated-mocks-op-service:
     machine: true


### PR DESCRIPTION
We should ignore submodules when check diff, otherwise
```
--- a/op-geth
+++ b/op-geth
@@ -1 +1 @@
-Subproject commit 1bb12cd77237ea71bd1307a2e1f8d5fae663b71a
+Subproject commit 6263f3d96c5b232fb97accb851bb8f66ceca555f
```

The original error can be found [here](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/44/workflows/2c095aa3-7729-453f-9491-9a1b0ce1a950/jobs/1008).