### PR TITLE
CircleCI: fix resource class in test: contracts-bedrock-coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -840,7 +840,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
         - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: xlarge
     parameters:
       test_flags:
         description: Additional flags to pass to the test command


### PR DESCRIPTION
The test [fails](https://app.circleci.com/pipelines/circleci/9n5VnJ75qFpuj33eU2XAuA/UykduNDM3FCwRU5gTixTkY/44/workflows/2c095aa3-7729-453f-9491-9a1b0ce1a950/jobs/1011) due to:
 
> Resource class docker for 2xlarge is not available for your project, or is not a valid resource class. This message will often appear if the pricing plan for this project does not support docker use.

