### PR TITLE
mod kurtosis version

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -37,7 +37,7 @@ anvil = "1.1.0"
 # Other dependencies
 codecov-uploader = "0.8.0"
 goreleaser-pro = "2.11.2"
-kurtosis = "1.8.1"
+kurtosis = "1.11.1"
 op-acceptor = "op-acceptor/v3.5.0"
 
 # Fake dependencies


### PR DESCRIPTION
In [opup_devnet_test.md](https://github.com/QuarkChain/pm/blob/main/L2/opup_devnet_test.md), we require the kurtosis version to be `1.11.1` since we're using latest etheream package directly.