### PR TITLE
Fix CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2516,7 +2516,7 @@ workflows:
             - op-program-docker-build
             - op-supervisor-docker-build
             - op-test-sequencer-docker-build
-            - go-tests-short
+            - go-tests-full
             - sanitize-op-program
           context:
             - circleci-repo-readonly-authenticated-github-tokens

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2315,15 +2315,13 @@ workflows:
             - cannon-prestate-quick
   main:
     when:
-      or:
-        - equal: ["webhook", << pipeline.trigger_source >>]
-        - and:
-            - equal: [true, <<pipeline.parameters.main_dispatch>>]
-            - equal: ["api", << pipeline.trigger_source >>]
-            - equal: [
-                  << pipeline.parameters.github-event-type >>,
-                  "__not_set__",
-                ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
+      and:
+          - equal: [true, <<pipeline.parameters.main_dispatch>>]
+          - equal: ["api", << pipeline.trigger_source >>]
+          - equal: [
+                << pipeline.parameters.github-event-type >>,
+                "__not_set__",
+              ] #this is to prevent triggering this workflow as the default value is always set for main_dispatch
     jobs:
       - initialize:
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1021,7 +1021,7 @@ jobs:
     circleci_ip_ranges: true
     docker:
       - image: <<pipeline.parameters.default_docker_image>>
-    resource_class: 2xlarge
+    resource_class: xlarge
     parameters:
       test_flags:
         description: Additional flags to pass to the test command

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2463,20 +2463,19 @@ workflows:
             - circleci-repo-readonly-authenticated-github-token
           requires:
             - contracts-bedrock-build
-      # Always run full tests on qkc
-      # - go-tests:
-      #     name: go-tests-short
-      #     parallelism: 4
-      #     no_output_timeout: 19m
-      #     test_timeout: 20m
-      #     requires:
-      #       - contracts-bedrock-build
-      #       - cannon-prestate-quick
-      #     context:
-      #       - circleci-repo-readonly-authenticated-github-token
-      #     filters:
-      #       branches:
-      #         ignore: develop # Run on all branches EXCEPT develop (PR branches only)
+      - go-tests:
+          name: go-tests-short
+          parallelism: 4
+          no_output_timeout: 19m
+          test_timeout: 20m
+          requires:
+            - contracts-bedrock-build
+            - cannon-prestate-quick
+          context:
+            - circleci-repo-readonly-authenticated-github-token
+          filters:
+            branches:
+              ignore: develop # Run on all branches EXCEPT develop (PR branches only)
       - go-tests:
           name: go-tests-full
           rule: "go-tests-ci" # Run full test suite instead of short
@@ -2484,6 +2483,7 @@ workflows:
           no_output_timeout: 89m # Longer timeout for full tests
           test_timeout: 90m
           notify: true
+          # Always run full tests on qkc
           # filters:
           #   branches:
           #     only: develop # Only runs on develop branch (post-merge)
@@ -2516,7 +2516,7 @@ workflows:
             - op-program-docker-build
             - op-supervisor-docker-build
             - op-test-sequencer-docker-build
-            - go-tests-full
+            - go-tests-short
             - sanitize-op-program
           context:
             - circleci-repo-readonly-authenticated-github-tokens


### PR DESCRIPTION
Fix config:
- 2xlarge is not available in `contracts-bedrock-coverage`: 
- remove main workflow trigger from github
- uncomment `go-tests-short` which is depended by other job