### PR TITLE
fix l2 blob test

### DIFF
--- a/op-e2e/l2blob/l2blob_test.go
+++ b/op-e2e/l2blob/l2blob_test.go
@@ -98,7 +98,7 @@ func sendTransactionWithBlobs(t *testing.T, ctx context.Context, l2Client *ethcl
 	require.NoError(t, err)
 	nonce, err := l2Client.NonceAt(ctx, crypto.PubkeyToAddress(sender.PublicKey), nil)
 	require.NoError(t, err)
-	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs, true)
+	sidecar, blobHashes, err := txmgr.MakeSidecar(blobs, false)
 	require.NoError(t, err)
 	tx := types.MustSignNewTx(sender, types.LatestSignerForChainID(chainID), &types.BlobTx{
 		ChainID:    uint256.NewInt(chainID.Uint64()),


### PR DESCRIPTION
This PR fixes the error below when running l2 blob test:

<img width="768" height="86" alt="image" src="https://github.com/user-attachments/assets/bd75371e-0183-427c-8aef-c5a684c46021" />


