### PR TITLE
CircleCI: fix rpc url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,11 +242,15 @@ export ENABLE_ANVIL=true && \
 export PARALLEL=$$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 endef
 
+# QKC: The following are removed to use environment variables for RPC URLs in CircleCI
+# export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io" && \
+# export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io" && \
+
 # Additional CI-specific environment variables
 define CI_ENV_VARS
 export OP_TESTLOG_FILE_LOGGER_OUTDIR=$$(realpath ./tmp/testlogs) && \
-export SEPOLIA_RPC_URL="https://ci-sepolia-l1-archive.optimism.io" && \
-export MAINNET_RPC_URL="https://ci-mainnet-l1-archive.optimism.io" && \
+if [ -z "$$SEPOLIA_RPC_URL" ]; then echo "ERROR: SEPOLIA_RPC_URL is not set"; exit 1; fi && \
+if [ -z "$$MAINNET_RPC_URL" ]; then echo "ERROR: MAINNET_RPC_URL is not set"; exit 1; fi && \
 export NAT_INTEROP_LOADTEST_TARGET=10 && \
 export NAT_INTEROP_LOADTEST_TIMEOUT=30s
 endef


### PR DESCRIPTION
Remove hardcoded RPC URL (403 forbidden) in Makefile, use the ones in environment variables instead.