### PR TITLE
merge_op_contracts_v4.1.0: allow ProxyAdmin or ProxyAdmin owner to perform guardian actions

### DIFF
--- a/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
+++ b/packages/contracts-bedrock/src/dispute/AnchorStateRegistry.sol
@@ -344,7 +344,8 @@ contract AnchorStateRegistry is ProxyAdminOwnedBase, Initializable, Reinitializa
     /// @notice Asserts that the caller is the Guardian.
     function _assertOnlyGuardian() internal view {
         if (msg.sender != systemConfig.guardian()) {
-            revert AnchorStateRegistry_Unauthorized();
+            /// QKC changes: we also allow the ProxyAdmin or ProxyAdmin owner to perform guardian actions
+            _assertOnlyProxyAdminOrProxyAdminOwner();
         }
     }
 }


### PR DESCRIPTION
We want to allow ProxyAdmin or ProxyAdmin owner to perform guardian actions for both `op-es` and the `merge_op_contracts_v4.1.0` branch.

**UPDATE**
Related PR: https://github.com/QuarkChain/optimism/pull/107