### PR TITLE
CircleCI: fix DeployOPChainInput: not set

### DIFF
--- a/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
+++ b/packages/contracts-bedrock/test/L1/OPContractsManager.t.sol
@@ -1635,6 +1635,7 @@ contract OPContractsManager_Deploy_Test is DeployOPChain_TestBase {
         doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
         doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
         doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
+        doi.set(doi.batchInbox.selector, opcm.chainIdToBatchInboxAddress(l2ChainId));
     }
 
     // This helper function is used to convert the input struct type defined in DeployOPChain.s.sol

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -506,5 +506,6 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
         doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
         doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
+        doi.set(doi.batchInbox.selector, opcm.chainIdToBatchInboxAddress(l2ChainId));
     }
 }

--- a/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
+++ b/packages/contracts-bedrock/test/opcm/DeployOPChain.t.sol
@@ -420,6 +420,7 @@ contract DeployOPChain_Test is DeployOPChain_TestBase {
         doi.set(doi.disputeSplitDepth.selector, disputeSplitDepth);
         doi.set(doi.disputeClockExtension.selector, disputeClockExtension);
         doi.set(doi.disputeMaxClockDuration.selector, disputeMaxClockDuration);
+        doi.set(doi.batchInbox.selector, opcm.chainIdToBatchInboxAddress(l2ChainId));
 
         deployOPChain.run(doi, doo);
 


### PR DESCRIPTION
Fix test failure:

>Ran 2 tests for test/opcm/DeployOPChain.t.sol:DeployOPChain_Test
[FAIL: DeployOPChainInput: not set; counterexample: calldata=0xdff1fb30099e510ef8d1cbd3fb5e79622e8f6c6658469efa2a96f183ca7250a7fee246c6 args=[0x099e510ef8d1cbd3fb5e79622e8f6c6658469efa2a96f183ca7250a7fee246c6]] testFuzz_run_memory_succeeds(bytes32) (runs: 0, μ: 0, ~: 0)
[FAIL: DeployOPChainInput: not set] test_customDisputeGame_customEnabled_succeeds() (gas: 404002)
Suite result: FAILED. 0 passed; 2 failed; 0 skipped; finished in 39.14ms (8.13ms CPU time)

>Ran 2 tests for test/opcm/DeployOPChain.t.sol:DeployOPChain_Test.dispute
[FAIL: DeployOPChainInput: not set; counterexample: calldata=0xdff1fb30099e510ef8d1cbd3fb5e79622e8f6c6658469efa2a96f183ca7250a7fee246c6 args=[0x099e510ef8d1cbd3fb5e79622e8f6c6658469efa2a96f183ca7250a7fee246c6]] testFuzz_run_memory_succeeds(bytes32) (runs: 0, μ: 0, ~: 0)
[FAIL: DeployOPChainInput: not set] test_customDisputeGame_customEnabled_succeeds() (gas: 406993)
Suite result: FAILED. 0 passed; 2 failed; 0 skipped; finished in 42.03ms (8.12ms CPU time)

Can be  verified by
```
forge test --match-path test/opcm/DeployOPChain.t.sol --match-contract DeployOPChain_Test
forge test --match-path test/L1/OPContractsManager.t.sol --match-contract OPContractsManager_Deploy_Test
```