### PR TITLE
CircleCI: fix forge build during go test

### DIFF
--- a/op-service/gnosis/contracts/script/DeploySafe.s.sol
+++ b/op-service/gnosis/contracts/script/DeploySafe.s.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.19;
 
 import { Script } from "forge-std/Script.sol";
 import { console } from "forge-std/console.sol";
-import { Safe as GnosisSafe } from "safe-contracts/Safe.sol";
-import { SafeProxyFactory as GnosisSafeProxyFactory } from "safe-contracts/proxies/SafeProxyFactory.sol";
+import { GnosisSafe } from "safe-contracts/GnosisSafe.sol";
+import { GnosisSafeProxyFactory } from "safe-contracts/proxies/GnosisSafeProxyFactory.sol";
 import { TestDelegateCall } from "src/TestDelegateCall.sol";
 
 contract DeploySafe is Script {


### PR DESCRIPTION
This is only for the go-tests to pass which involves a contract build issue caused by different contract names in `lib/safe-contracts` between branch `op-es` and  `merge_op_contracts_v4.1.0`:
>=== RUN   TestGnosisClient
    helpers.go:52: Contracts directory: /root/dl/optimism/op-service/gnosis/contracts
    helpers.go:53: Shared lib directory: /root/dl/optimism/packages/contracts-bedrock/lib
    helpers.go:84: Building contracts...
    helpers.go:87: 
        	Error Trace:	/root/dl/optimism/op-service/gnosis/integration_test/helpers.go:87
        	            				/root/dl/optimism/op-service/gnosis/integration_test/integration_test.go:37
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestGnosisClient
        	Messages:   	Failed to build contracts: [2m2025-11-19T06:26:55.776173Z[0m [31mERROR[0m [2mfoundry_compilers_artifacts_solc::sources[0m[2m:[0m [3merror[0m[2m=[0m"/root/dl/optimism/op-service/gnosis/contracts/../../../packages/contracts-bedrock/lib/safe-contracts/contracts/Safe.sol": No such file or directory (os error 2)
        	            	Error: failed to resolve file: "/root/dl/optimism/op-service/gnosis/contracts/../../../packages/contracts-bedrock/lib/safe-contracts/contracts/Safe.sol": No such file or directory (os error 2); check configured remappings
        	            		--> /root/dl/optimism/op-service/gnosis/contracts/script/DeploySafe.s.sol
        	            		safe-contracts/Safe.sol
--- FAIL: TestGnosisClient (0.43s)