### PR TITLE
fix TestInitLiveStrategy_OPCMReuseLogicSepolia

### DIFF
--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -120,7 +120,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 				ProtocolVersionsProxy:    superCfg.ProtocolVersionsAddr,
 				ProtocolVersionsImpl:     common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 				SuperchainConfigProxy:    superCfg.SuperchainConfigAddr,
-				SuperchainConfigImpl:     common.HexToAddress("0xCe28685EB204186b557133766eCA00334EB441E4"),
+				SuperchainConfigImpl:     common.HexToAddress("0xb08Cc720F511062537ca78BdB0AE691F04F5a957"),
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM


### PR DESCRIPTION
Fixes https://github.com/QuarkChain/optimism/issues/131.

Looks like upstream has changed the implementation CA, this change is consistent with [here](https://github.com/ethereum-optimism/optimism/blob/66737753b3408f2c96de4659601a8e07e6daaff3/op-deployer/pkg/deployer/pipeline/init_test.go#L123)