### PR TITLE
fix: update expected SuperchainConfigProxy impl and conditionally upd…

### DIFF
--- a/op-deployer/pkg/deployer/integration_test/apply_test.go
+++ b/op-deployer/pkg/deployer/integration_test/apply_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/bootstrap"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/broadcaster"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/inspect"
@@ -33,6 +34,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/standard"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/state"
 	"github.com/ethereum-optimism/optimism/op-deployer/pkg/deployer/testutil"
+	opbindings "github.com/ethereum-optimism/optimism/op-e2e/bindings"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -46,6 +48,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-chain-ops/genesis"
 	"github.com/ethereum-optimism/optimism/op-service/predeploys"
 	"github.com/ethereum-optimism/optimism/op-service/testlog"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -717,6 +720,18 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 	impls, err := bootstrap.Implementations(ctx, implementationsConfig)
 	require.NoError(t, err)
 
+	versionClient, err := ethclient.Dial(implementationsConfig.L1RPCUrl)
+	require.NoError(t, err)
+	defer versionClient.Close()
+
+	shouldUpgradeSuperchainConfig, err := needsSuperchainConfigUpgrade(
+		ctx,
+		versionClient,
+		implementationsConfig.SuperchainConfigProxy,
+		impls.SuperchainConfigImpl,
+	)
+	require.NoError(t, err)
+
 	// Now test the OPCM upgrade using the deployed impls.Opcm
 	t.Run("opcm upgrade test", func(t *testing.T) {
 		// Create script host for the upgrade
@@ -733,18 +748,22 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 		)
 		require.NoError(t, err)
 
-		// First run upgradeSuperchainConfig because the version on the fork is < than that
-		// of the contracts-bedrock folder so upgrading directly would revert.
-		t.Run("upgrade superchain config", func(t *testing.T) {
-			upgradeConfig := embedded.UpgradeSuperchainConfigInput{
-				Prank:            superchainProxyAdminOwner,
-				Opcm:             impls.Opcm,
-				SuperchainConfig: implementationsConfig.SuperchainConfigProxy,
-			}
+		// Only run the superchain config upgrade if the live superchain config is behind the freshly deployed
+		// implementation. Running the script when versions match will revert and panic the test harness.
+		if shouldUpgradeSuperchainConfig {
+			t.Run("upgrade superchain config", func(t *testing.T) {
+				upgradeConfig := embedded.UpgradeSuperchainConfigInput{
+					Prank:            superchainProxyAdminOwner,
+					Opcm:             impls.Opcm,
+					SuperchainConfig: implementationsConfig.SuperchainConfigProxy,
+				}
 
-			err = embedded.UpgradeSuperchainConfig(host, upgradeConfig)
-			require.NoError(t, err, "Superchain config upgrade should succeed")
-		})
+				err = embedded.UpgradeSuperchainConfig(host, upgradeConfig)
+				require.NoError(t, err, "Superchain config upgrade should succeed")
+			})
+		} else {
+			t.Log("Skipping superchain config upgrade; onchain version is already up to date")
+		}
 
 		// Then run the OPCM upgrade
 		var cannonKonaPrestate common.Hash
@@ -770,6 +789,44 @@ func runEndToEndBootstrapAndApplyUpgradeTest(t *testing.T, afactsFS foundry.Stat
 			require.NoError(t, err, "OPCM upgrade should succeed")
 		})
 	})
+}
+
+func needsSuperchainConfigUpgrade(
+	ctx context.Context,
+	client *ethclient.Client,
+	currentProxy, targetImpl common.Address,
+) (bool, error) {
+	currentVersion, err := superchainConfigVersion(ctx, client, currentProxy)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch proxy superchain config version: %w", err)
+	}
+
+	targetVersion, err := superchainConfigVersion(ctx, client, targetImpl)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch implementation superchain config version: %w", err)
+	}
+
+	return currentVersion.LessThan(targetVersion), nil
+}
+
+func superchainConfigVersion(
+	ctx context.Context,
+	client *ethclient.Client,
+	addr common.Address,
+) (*semver.Version, error) {
+	contract, err := opbindings.NewSuperchainConfig(addr, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to bind superchain config at %s: %w", addr.Hex(), err)
+	}
+	versionStr, err := contract.Version(&bind.CallOpts{Context: ctx})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read version from %s: %w", addr.Hex(), err)
+	}
+	version, err := semver.NewVersion(versionStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse version %q from %s: %w", versionStr, addr.Hex(), err)
+	}
+	return version, nil
 }
 
 func setupGenesisChain(t *testing.T, l1ChainID uint64) (deployer.ApplyPipelineOpts, *state.Intent, *state.State) {

--- a/op-deployer/pkg/deployer/pipeline/init_test.go
+++ b/op-deployer/pkg/deployer/pipeline/init_test.go
@@ -120,7 +120,7 @@ func TestInitLiveStrategy_OPCMReuseLogicSepolia(t *testing.T) {
 				ProtocolVersionsProxy:    superCfg.ProtocolVersionsAddr,
 				ProtocolVersionsImpl:     common.HexToAddress("0x37E15e4d6DFFa9e5E320Ee1eC036922E563CB76C"),
 				SuperchainConfigProxy:    superCfg.SuperchainConfigAddr,
-				SuperchainConfigImpl:     common.HexToAddress("0xCe28685EB204186b557133766eCA00334EB441E4"),
+				SuperchainConfigImpl:     common.HexToAddress("0xb08Cc720F511062537ca78BdB0AE691F04F5a957"),
 			}
 
 			// Tagged locator will reuse the existing superchain and OPCM


### PR DESCRIPTION
Fixes https://github.com/QuarkChain/optimism/issues/132.

The revert is caused [here](https://github.com/QuarkChain/optimism/blob/d2e3556e2292c8cb32428c3188fbb1a783e9bf25/packages/contracts-bedrock/src/L1/OPContractsManager.sol#L1098).

The reason is the sepolia SuperchainConfig contract([link](https://sepolia.etherscan.io/address/0xC2Be75506d5724086DEB7245bd260Cc9753911Be)) is already of version "2.4.0", the same as our in-place contract, thus triggering the revert .

The upstream already fixed it in this PR: https://github.com/ethereum-optimism/optimism/pull/18293


After cherry-pick, `go test ./op-deployer/pkg/deployer/integration_test -run "TestEndToEndBootstrapApplyWithUpgrade/cannon-kona"` passes.