### PR TITLE
CI: fix unrecognized 4 byte signature: dac6e63a

### DIFF
--- a/op-chain-ops/interopgen/deploy.go
+++ b/op-chain-ops/interopgen/deploy.go
@@ -229,6 +229,7 @@ func DeployL2ToL1(l1Host *script.Host, superCfg *SuperchainConfig, superDeployme
 		OpChainProxyAdminOwner:       superCfg.ProxyAdminOwner,
 		SystemConfigOwner:            cfg.SystemConfigOwner,
 		Batcher:                      cfg.BatchSenderAddress,
+		BatchInbox:                   cfg.BatchInboxAddress,
 		UnsafeBlockSigner:            cfg.P2PSequencerAddress,
 		Proposer:                     cfg.Proposer,
 		Challenger:                   cfg.Challenger,

--- a/op-deployer/pkg/deployer/opcm/opchain.go
+++ b/op-deployer/pkg/deployer/opcm/opchain.go
@@ -22,6 +22,7 @@ type DeployOPChainInput struct {
 	OpChainProxyAdminOwner common.Address
 	SystemConfigOwner      common.Address
 	Batcher                common.Address
+	BatchInbox             common.Address
 	UnsafeBlockSigner      common.Address
 	Proposer               common.Address
 	Challenger             common.Address

--- a/op-deployer/pkg/deployer/pipeline/opchain.go
+++ b/op-deployer/pkg/deployer/pipeline/opchain.go
@@ -94,6 +94,7 @@ func makeDCI(intent *state.Intent, thisIntent *state.ChainIntent, chainID common
 		OpChainProxyAdminOwner:       thisIntent.Roles.L1ProxyAdminOwner,
 		SystemConfigOwner:            thisIntent.Roles.SystemConfigOwner,
 		Batcher:                      thisIntent.Roles.Batcher,
+		BatchInbox:                   state.CalculateBatchInboxAddr(chainID),
 		UnsafeBlockSigner:            thisIntent.Roles.UnsafeBlockSigner,
 		Proposer:                     thisIntent.Roles.Proposer,
 		Challenger:                   thisIntent.Roles.Challenger,

--- a/op-deployer/pkg/deployer/state/deploy_config.go
+++ b/op-deployer/pkg/deployer/state/deploy_config.go
@@ -85,7 +85,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 				SequencerWindowSize:       3600,
 				ChannelTimeoutBedrock:     300,
 				SystemConfigStartBlock:    0,
-				BatchInboxAddress:         calculateBatchInboxAddr(chainState.ID),
+				BatchInboxAddress:         CalculateBatchInboxAddr(chainState.ID),
 			},
 			OperatorDeployConfig: genesis.OperatorDeployConfig{
 				BatchSenderAddress:  chainIntent.Roles.Batcher,
@@ -166,7 +166,7 @@ func CombineDeployConfig(intent *Intent, chainIntent *ChainIntent, state *State,
 	return cfg, nil
 }
 
-func calculateBatchInboxAddr(chainID common.Hash) common.Address {
+func CalculateBatchInboxAddr(chainID common.Hash) common.Address {
 	var out common.Address
 	copy(out[1:], crypto.Keccak256(chainID[:])[:19])
 	return out


### PR DESCRIPTION
```
go test ./op-acceptance-tests/tests/interop/contract -count=1 -v

t=2025-11-22T04:25:06.004+0100 lvl=info msg="initializing orchestrator" backend=sysgo
t=2025-11-22T04:25:06.004+0100 lvl=info msg="Setting up"
t=2025-11-22T04:25:06.296+0100 lvl=info msg="initializing pipeline" stage=init strategy=genesis
t=2025-11-22T04:25:06.296+0100 lvl=info msg="deploying superchain" stage=deploy-superchain
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=Fault addr=0xD5169864D6046B87309e0D147099291eDD157030 label=ProtocolVersionsProxy err="execution reverted" depth=3 op=253 byte4=0x38d38c97
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=callframe depth=1 byte4=0xff07a313 addr=0xfdAf657f7146c1AB9db4d70cEd5FDEa7dC4906c0 callsite="" label=DeploySuperchain
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=callframe depth=2 byte4=0x38d38c97 addr=0xD5169864D6046B87309e0D147099291eDD157030 callsite="" label=ProtocolVersionsProxy
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=callframe depth=3 byte4=0x38d38c97 addr=0xD5169864D6046B87309e0D147099291eDD157030 callsite="" label=ProtocolVersionsProxy
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=Revert addr=0xD5169864D6046B87309e0D147099291eDD157030 label=ProtocolVersionsProxy err="execution reverted" revertData=0x depth=2
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=Fault addr=0xD5169864D6046B87309e0D147099291eDD157030 label=ProtocolVersionsProxy err="execution reverted" depth=2 op=253 byte4=0x38d38c97
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=callframe depth=1 byte4=0xff07a313 addr=0xfdAf657f7146c1AB9db4d70cEd5FDEa7dC4906c0 callsite="" label=DeploySuperchain
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=callframe depth=2 byte4=0x38d38c97 addr=0xD5169864D6046B87309e0D147099291eDD157030 callsite="" label=ProtocolVersionsProxy
t=2025-11-22T04:25:06.308+0100 lvl=warn msg=Revert addr=0xD5169864D6046B87309e0D147099291eDD157030 label=ProtocolVersionsProxy err="execution reverted" revertData=0x depth=1
t=2025-11-22T04:25:06.308+0100 lvl=info msg="deploying implementations" stage=deploy-implementations
t=2025-11-22T04:25:06.773+0100 lvl=info msg="Running chain assertions on the DelayedWETH implementation at 0x33Dadc2d1aA9BB613A7AE6B28425eA00D44c6998" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.773+0100 lvl=info msg="Running chain assertions on the DisputeGameFactory implementation at 0x33D1e8571a85a538ed3D5A4d88f46C112383439D" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.773+0100 lvl=info msg="Running chain assertions on the L1CrossDomainMessenger implementation at 0x22D12E0FAebD62d429514A65EBAe32dd316c12D6" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.773+0100 lvl=warn msg=Fault addr=0x22D12E0FAebD62d429514A65EBAe32dd316c12D6 label=L1CrossDomainMessengerImpl err="execution reverted" depth=2 op=253 byte4=0x3e47158c
t=2025-11-22T04:25:06.773+0100 lvl=warn msg=callframe depth=1 byte4=0xd194827c addr=0x8f0818c1e0a4cA9Bc005f61428f7f8a371464D38 callsite="" label=DeployImplementations
t=2025-11-22T04:25:06.773+0100 lvl=warn msg=callframe depth=2 byte4=0x3e47158c addr=0x22D12E0FAebD62d429514A65EBAe32dd316c12D6 callsite="" label=L1CrossDomainMessengerImpl
t=2025-11-22T04:25:06.774+0100 lvl=warn msg=Revert addr=0x22D12E0FAebD62d429514A65EBAe32dd316c12D6 label=L1CrossDomainMessengerImpl err="execution reverted" revertData=0x54e433cd depth=1
t=2025-11-22T04:25:06.774+0100 lvl=info msg="Running chain assertions on the L1ERC721Bridge implementation at 0x7f1d12fB2911EB095278085f721e644C1f675696" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.774+0100 lvl=warn msg=Fault addr=0x7f1d12fB2911EB095278085f721e644C1f675696 label=L1ERC721BridgeImpl err="execution reverted" depth=2 op=253 byte4=0x3e47158c
t=2025-11-22T04:25:06.774+0100 lvl=warn msg=callframe depth=1 byte4=0xd194827c addr=0x8f0818c1e0a4cA9Bc005f61428f7f8a371464D38 callsite="" label=DeployImplementations
t=2025-11-22T04:25:06.774+0100 lvl=warn msg=callframe depth=2 byte4=0x3e47158c addr=0x7f1d12fB2911EB095278085f721e644C1f675696 callsite="" label=L1ERC721BridgeImpl
t=2025-11-22T04:25:06.774+0100 lvl=warn msg=Revert addr=0x7f1d12fB2911EB095278085f721e644C1f675696 label=L1ERC721BridgeImpl err="execution reverted" revertData=0x54e433cd depth=1
t=2025-11-22T04:25:06.774+0100 lvl=info msg="Running chain assertions on the L1StandardBridge implementation at 0xe32B192fb1DcA88fCB1C56B3ACb429e32238aDCb" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.774+0100 lvl=info msg="Running chain assertions on the MIPS at 0x07BABE08EE4D07dBA236530183B24055535A7011" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.774+0100 lvl=info msg="Running chain assertions on the OPContractsManager at 0xD3405E9D3CcD676E9facff71C78B3b0238C0b8C1" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.795+0100 lvl=info msg="Running chain assertions on the OptimismMintableERC20Factory implementation at 0x5493f4677A186f64805fe7317D6993ba4863988F" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.795+0100 lvl=info msg="Running chain assertions on the OptimismPortal2 implementation at 0x9ef630D9d41AdAC7AB6D67d6E2F6aFbdC20d43E0" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.795+0100 lvl=info msg="Running chain assertions on the ETHLockbox implementation at 0x784d2F03593A42A6E4676A012762F18775ecbBe6" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.795+0100 lvl=info msg="Running chain assertions on the SystemConfig implementation at 0x2bFE4A5Bd5A41e9d848d843ebCDFa15954e9A557" sender=0x98e503f35D0a019cB0a251aD243a4cCFCF371F46
t=2025-11-22T04:25:06.796+0100 lvl=info msg="deploying OP chain using local allocs" stage=deploy-opchain id=0x0000000000000000000000000000000000000000000000000000000000000385
t=2025-11-22T04:25:06.843+0100 lvl=warn msg=callframe depth=1 byte4=0xfc4dcacb addr=0xd18d9635A78708D370080e898a27a0751575a0dc callsite="" label=DeployOPChain
t=2025-11-22T04:25:06.843+0100 lvl=warn msg=Revert addr=0xd18d9635A78708D370080e898a27a0751575a0dc label=DeployOPChain err="execution reverted" revertMsg="unrecognized 4 byte signature: dac6e63a" depth=1
t=2025-11-22T04:25:06.843+0100 lvl=warn msg=Fault addr=0xd18d9635A78708D370080e898a27a0751575a0dc label=DeployOPChain err="execution reverted" depth=1 op=253 byte4=0xfc4dcacb
t=2025-11-22T04:25:06.843+0100 lvl=warn msg=callframe depth=1 byte4=0xfc4dcacb addr=0xd18d9635A78708D370080e898a27a0751575a0dc callsite="" label=DeployOPChain
t=2025-11-22T04:25:06.843+0100 lvl=warn msg=Revert addr=0xd18d9635A78708D370080e898a27a0751575a0dc label=DeployOPChain err="execution reverted" revertMsg="unrecognized 4 byte signature: dac6e63a" depth=0
t=2025-11-22T04:25:06.843+0100 lvl=error msg="\n\tError Trace:\t/root/dl/optimism/op-devstack/sysgo/deployer.go:396\n\t            \t\t\t\t/root/dl/optimism/op-devstack/sysgo/deployer.go:71\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:166\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:117\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:117\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:248\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:166\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:117\n\t            \t\t\t\t/root/dl/optimism/op-devstack/stack/orchestrator.go:70\n\t            \t\t\t\t/root/dl/optimism/op-devstack/presets/orchestrator.go:141\n\t            \t\t\t\t/root/dl/optimism/op-devstack/presets/orchestrator.go:109\n\t            \t\t\t\t/root/dl/optimism/op-devstack/presets/orchestrator.go:113\n\t            \t\t\t\t/root/dl/optimism/op-acceptance-tests/tests/interop/contract/init_test.go:10\n\tError:      \tReceived unexpected error:\n\t            \terror in pipeline stage apply: error deploying OP chain: failed to run DeployOPChain.s.sol script: execution reverted at 0xd18d9635A78708D370080e898a27a0751575a0dc with message: unrecognized 4 byte signature: dac6e63a\n\tTest:       \tpkg\n"
t=2025-11-22T04:25:06.843+0100 lvl=error msg="Main failed"
goroutine 1 [running]:
runtime/debug.Stack()
	/root/.local/share/mise/installs/go/1.23.8/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
	/root/.local/share/mise/installs/go/1.23.8/src/runtime/debug/stack.go:18 +0x13
github.com/ethereum-optimism/optimism/op-devstack/presets.DoMain.func1.3(0x0)
	/root/dl/optimism/op-devstack/presets/orchestrator.go:92 +0x51
github.com/ethereum-optimism/optimism/op-devstack/devtest.(*implP).Fail(...)
	/root/dl/optimism/op-devstack/devtest/package.go:84
github.com/ethereum-optimism/optimism/op-devstack/devtest.(*implP).Errorf(0xc000204e00, {0x2b86bf5?, 0x10?}, {0xc000884540?, 0x2806c40?, 0x7e15720?})
	/root/dl/optimism/op-devstack/devtest/package.go:80 +0x6a
github.com/stretchr/testify/assert.Fail({0x70fca66822e8, 0xc000204e00}, {0xc000dd0c00, 0xf4}, {0x0, 0x0, 0x0})
	/root/go/pkg/mod/github.com/stretchr/testify@v1.10.0/assert/assertions.go:369 +0x370
github.com/stretchr/testify/assert.NoError({0x70fca66822e8, 0xc000204e00}, {0x65bd3a0, 0xc0003b9f20}, {0x0, 0x0, 0x0})
	/root/go/pkg/mod/github.com/stretchr/testify@v1.10.0/assert/assertions.go:1586 +0x125
github.com/stretchr/testify/require.NoError({0x65ced70, 0xc000204e00}, {0x65bd3a0, 0xc0003b9f20}, {0x0, 0x0, 0x0})
	/root/go/pkg/mod/github.com/stretchr/testify@v1.10.0/require/require.go:1354 +0xb0
github.com/stretchr/testify/require.(*Assertions).NoError(0xc0003b93c0, {0x65bd3a0, 0xc0003b9f20}, {0x0, 0x0, 0x0})
	/root/go/pkg/mod/github.com/stretchr/testify@v1.10.0/require/require_forward.go:1072 +0x9d
github.com/ethereum-optimism/optimism/op-devstack/sysgo.(*worldBuilder).Build(0xc00046a000)
	/root/dl/optimism/op-devstack/sysgo/deployer.go:396 +0x365
github.com/ethereum-optimism/optimism/op-devstack/sysgo.baseInteropSystem.WithDeployer.func4(0xc0009dc008)
	/root/dl/optimism/op-devstack/sysgo/deployer.go:71 +0xb1
github.com/ethereum-optimism/optimism/op-devstack/stack.FnOption[...].Deploy(...)
	/root/dl/optimism/op-devstack/stack/orchestrator.go:166
github.com/ethereum-optimism/optimism/op-devstack/stack.CombinedOption[...].Deploy(...)
	/root/dl/optimism/op-devstack/stack/orchestrator.go:117
github.com/ethereum-optimism/optimism/op-devstack/stack.CombinedOption[...].Deploy(...)
	/root/dl/optimism/op-devstack/stack/orchestrator.go:117
github.com/ethereum-optimism/optimism/op-devstack/stack.MakeCommon[...].func2()
	/root/dl/optimism/op-devstack/stack/orchestrator.go:248 +0x33
github.com/ethereum-optimism/optimism/op-devstack/stack.FnOption[...].Deploy(...)
	/root/dl/optimism/op-devstack/stack/orchestrator.go:166
github.com/ethereum-optimism/optimism/op-devstack/stack.CombinedOption[...].Deploy(...)
	/root/dl/optimism/op-devstack/stack/orchestrator.go:117
github.com/ethereum-optimism/optimism/op-devstack/stack.ApplyOptionLifecycle[...]({0x65f0038?, 0xc00113a900}, {0x65e2dd0, 0xc0009dc008})
	/root/dl/optimism/op-devstack/stack/orchestrator.go:70 +0x4b
github.com/ethereum-optimism/optimism/op-devstack/presets.initOrchestrator({0x65e2c48, 0xc0007d82a0}, {0x660ba68, 0xc000204e00}, {0x65f0038, 0xc00113a900})
	/root/dl/optimism/op-devstack/presets/orchestrator.go:141 +0x347
github.com/ethereum-optimism/optimism/op-devstack/presets.DoMain.func1({0xc000663350, 0x1, 0x1}, {0x65bd0c0, 0xc000226c80})
	/root/dl/optimism/op-devstack/presets/orchestrator.go:109 +0x758
github.com/ethereum-optimism/optimism/op-devstack/presets.DoMain({0x65bd0c0?, 0xc000226c80?}, {0xc000663350?, 0xc00006bea0?, 0x561f17?})
	/root/dl/optimism/op-devstack/presets/orchestrator.go:113 +0x3b
github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/contract.TestMain(0xc000226c80)
	/root/dl/optimism/op-acceptance-tests/tests/interop/contract/init_test.go:10 +0x73
main.main()
	_testmain.go:47 +0xa8

Exiting, code: 1
FAIL	github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/interop/contract	2.419s
FAIL
```
