### PR TITLE
feat(op-reth): add Soul Gas Token (SGT) support with acceptance tests

### DIFF
--- a/op-acceptance-tests/acceptance-tests.yaml
+++ b/op-acceptance-tests/acceptance-tests.yaml
@@ -185,6 +185,12 @@ gates:
       - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/custom_gas_token
         timeout: 10m
 
+  - id: sgt
+    description: "Soul Gas Token (SGT) tests."
+    tests:
+      - package: github.com/ethereum-optimism/optimism/op-acceptance-tests/tests/sgt
+        timeout: 10m
+
   - id: supernode
     description: "Supernode tests - tests for the op-supernode multi-chain consensus layer."
     tests:

--- a/op-acceptance-tests/justfile
+++ b/op-acceptance-tests/justfile
@@ -17,6 +17,9 @@ interop:
 cgt:
     @just acceptance-test "" cgt
 
+sgt:
+    @just acceptance-test "" sgt
+
 
 # Run acceptance tests with mise-managed binary
 # Usage: just acceptance-test [devnet] [gate]

--- a/op-acceptance-tests/tests/sgt/deposit_test.go
+++ b/op-acceptance-tests/tests/sgt/deposit_test.go
@@ -1,0 +1,125 @@
+package sgt
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+)
+
+// TestSGT_DepositVia_BatchDepositForAll verifies that SGT can be deposited
+// using the batchDepositForAll function and the balance is correctly reflected.
+func TestSGT_DepositFunctionSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	// Create a funder with native balance
+	funder := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+	recipient := sys.Wallet.NewEOA(sys.L2EL)
+
+	// Check recipient starts with zero SGT
+	preSGT := h.GetSGTBalance(recipient.Address())
+	t.Require().Equal(0, preSGT.Sign(), "recipient should start with zero SGT")
+
+	// Deposit SGT to recipient
+	depositAmount := big.NewInt(10000)
+	h.DepositSGT(funder, recipient.Address(), depositAmount)
+
+	// Verify SGT balance after deposit
+	postSGT := h.GetSGTBalance(recipient.Address())
+	t.Require().Equal(0, depositAmount.Cmp(postSGT),
+		"SGT balance should equal deposit amount: got %s, want %s", postSGT, depositAmount)
+}
+
+// TestSGT_DepositAccumulation verifies that multiple SGT deposits accumulate correctly.
+func TestSGT_DepositAccumulation(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	funder := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+	recipient := sys.Wallet.NewEOA(sys.L2EL)
+
+	firstDeposit := big.NewInt(5000)
+	secondDeposit := big.NewInt(3000)
+
+	// First deposit
+	h.DepositSGT(funder, recipient.Address(), firstDeposit)
+	bal1 := h.GetSGTBalance(recipient.Address())
+	t.Require().Equal(0, firstDeposit.Cmp(bal1), "after first deposit")
+
+	// Second deposit
+	h.DepositSGT(funder, recipient.Address(), secondDeposit)
+	bal2 := h.GetSGTBalance(recipient.Address())
+	expected := new(big.Int).Add(firstDeposit, secondDeposit)
+	t.Require().Equal(0, expected.Cmp(bal2), "after second deposit: got %s, want %s", bal2, expected)
+}
+
+// TestSGT_MultiAccountIndependence verifies that SGT deposits to different
+// accounts are independent and do not affect each other's balances.
+func TestSGT_MultiAccountIndependence(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	funder := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+	alice := sys.Wallet.NewEOA(sys.L2EL)
+	bob := sys.Wallet.NewEOA(sys.L2EL)
+
+	aliceDeposit := big.NewInt(7000)
+	bobDeposit := big.NewInt(3000)
+
+	// Deposit different amounts to each account
+	h.DepositSGT(funder, alice.Address(), aliceDeposit)
+	h.DepositSGT(funder, bob.Address(), bobDeposit)
+
+	// Verify each account has the correct balance
+	aliceBal := h.GetSGTBalance(alice.Address())
+	bobBal := h.GetSGTBalance(bob.Address())
+
+	t.Require().Equal(0, aliceDeposit.Cmp(aliceBal), "Alice SGT balance mismatch")
+	t.Require().Equal(0, bobDeposit.Cmp(bobBal), "Bob SGT balance mismatch")
+
+	// Deposit more to Alice; Bob should be unaffected
+	h.DepositSGT(funder, alice.Address(), aliceDeposit)
+
+	aliceBal2 := h.GetSGTBalance(alice.Address())
+	bobBal2 := h.GetSGTBalance(bob.Address())
+
+	expectedAlice := new(big.Int).Add(aliceDeposit, aliceDeposit)
+	t.Require().Equal(0, expectedAlice.Cmp(aliceBal2), "Alice SGT balance after second deposit")
+	t.Require().Equal(0, bobDeposit.Cmp(bobBal2), "Bob SGT balance should be unchanged")
+}
+
+// TestSGT_DepositCreatesNativeBackedBalance verifies that depositing SGT also locks
+// native ETH in the SGT contract (since nativeBacked=true in the preset).
+func TestSGT_DepositNativeBackingVerification(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	funder := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+
+	// Get SGT contract's native balance before deposit
+	preContractBalance := h.GetNativeBalance(sgtAddr)
+
+	depositAmount := big.NewInt(100000)
+	calldata := encodeBatchDepositForAll(funder.Address(), depositAmount)
+	funder.Transact(
+		funder.Plan(),
+		txplan.WithTo(&sgtAddr),
+		txplan.WithEth(depositAmount),
+		txplan.WithData(calldata),
+		txplan.WithGasLimit(200000),
+	)
+
+	// The SGT contract should have received the native ETH
+	postContractBalance := h.GetNativeBalance(sgtAddr)
+	diff := new(big.Int).Sub(postContractBalance, preContractBalance)
+	t.Require().Equal(0, depositAmount.Cmp(diff),
+		"SGT contract native balance should increase by deposit amount: got %s, want %s", diff, depositAmount)
+}

--- a/op-acceptance-tests/tests/sgt/gas_payment_test.go
+++ b/op-acceptance-tests/tests/sgt/gas_payment_test.go
@@ -1,0 +1,347 @@
+package sgt
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// largeSGT is a value large enough to fully cover gas costs on devnet (including L1 data fees).
+var largeSGT = new(big.Int).Mul(big.NewInt(10), big.NewInt(1e18)) // 10 ETH
+
+// largeNative is a value large enough to fully cover gas costs on devnet.
+var largeNative = new(big.Int).Mul(big.NewInt(5), big.NewInt(1e18)) // 5 ETH
+
+// smallBalance is too small to cover gas by itself.
+var smallBalance = big.NewInt(10_000)
+
+// TestSGT_NativaGasPaymentWithoutSGTSuccess verifies gas is paid entirely from native
+// balance when the account has no SGT.
+func TestSGT_NativaGasPaymentWithoutSGTSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, big.NewInt(0), largeNative)
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+	vaultBefore := h.CalcVaultBalance()
+
+	receipt := executeTransfer(t, h, account, dummyAddr, big.NewInt(0))
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	vaultAfter := h.CalcVaultBalance()
+
+	// Vault increased by gas cost
+	vaultDiff := new(big.Int).Sub(vaultAfter, vaultBefore)
+	t.Require().Equal(0, vaultDiff.Cmp(gasCost), "vault balance diff should equal gas cost")
+
+	// SGT should remain zero
+	t.Require().Equal(0, postSGT.Sign(), "SGT balance should remain zero")
+
+	// Balance invariant
+	h.InvariantBalanceCheck(account.Address(), gasCost, big.NewInt(0), preSGT, preNative, postSGT, false)
+}
+
+// TestSGT_FullSGTGasPaymentWithoutNativeBalanceSuccess verifies gas is paid entirely
+// from SGT when the account has no native balance.
+func TestSGT_FullSGTGasPaymentWithoutNativeBalanceSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, largeSGT, big.NewInt(0))
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+	vaultBefore := h.CalcVaultBalance()
+
+	receipt := executeTransfer(t, h, account, dummyAddr, big.NewInt(0))
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	vaultAfter := h.CalcVaultBalance()
+
+	// Vault increased by gas cost
+	vaultDiff := new(big.Int).Sub(vaultAfter, vaultBefore)
+	t.Require().Equal(0, vaultDiff.Cmp(gasCost), "vault balance diff should equal gas cost")
+
+	// SGT should decrease by gas cost
+	expectedSGT := new(big.Int).Sub(preSGT, gasCost)
+	t.Require().Equal(0, expectedSGT.Cmp(postSGT), "SGT should be reduced by gas cost")
+
+	h.InvariantBalanceCheck(account.Address(), gasCost, big.NewInt(0), preSGT, preNative, postSGT, true)
+}
+
+// TestSGT_FullSGTGasPaymentWithNativeBalanceSuccess verifies that when both SGT and
+// native balances are available, SGT is used first for gas payment.
+func TestSGT_FullSGTGasPaymentWithNativeBalanceSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, largeSGT, largeNative)
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+	vaultBefore := h.CalcVaultBalance()
+
+	receipt := executeTransfer(t, h, account, dummyAddr, big.NewInt(0))
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	postNative := h.GetNativeBalance(account.Address())
+	vaultAfter := h.CalcVaultBalance()
+
+	// Vault increased by gas cost
+	vaultDiff := new(big.Int).Sub(vaultAfter, vaultBefore)
+	t.Require().Equal(0, vaultDiff.Cmp(gasCost), "vault balance diff should equal gas cost")
+
+	// SGT should be used first (deduction: SGT first -> native second)
+	expectedSGT := new(big.Int).Sub(preSGT, gasCost)
+	t.Require().Equal(0, expectedSGT.Cmp(postSGT), "SGT should be reduced by gas cost")
+
+	// Native should remain unchanged (SGT covers all gas)
+	t.Require().Equal(0, preNative.Cmp(postNative), "native should not change (SGT priority)")
+
+	h.InvariantBalanceCheck(account.Address(), gasCost, big.NewInt(0), preSGT, preNative, postSGT, true)
+}
+
+// TestSGT_PartialSGTGasPaymentSuccess verifies that when SGT balance is less than gas
+// cost, SGT is fully spent and the remainder is paid from native balance.
+func TestSGT_PartialSGTGasPaymentSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, big.NewInt(1000), largeNative)
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+	vaultBefore := h.CalcVaultBalance()
+
+	receipt := executeTransfer(t, h, account, dummyAddr, big.NewInt(0))
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	vaultAfter := h.CalcVaultBalance()
+
+	// Vault increased by gas cost
+	vaultDiff := new(big.Int).Sub(vaultAfter, vaultBefore)
+	t.Require().Equal(0, vaultDiff.Cmp(gasCost), "vault balance diff should equal gas cost")
+
+	// SGT should be fully spent
+	t.Require().Equal(0, postSGT.Sign(), "SGT should be fully spent in partial payment")
+
+	h.InvariantBalanceCheck(account.Address(), gasCost, big.NewInt(0), preSGT, preNative, postSGT, true)
+}
+
+// TestSGT_FullSGTGasPaymentAndNonZeroTxValueWithSufficientNativeBalanceSuccess verifies
+// that SGT covers gas while tx value is paid from native balance.
+func TestSGT_FullSGTGasPaymentAndNonZeroTxValueWithSufficientNativeBalanceSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	txValue := big.NewInt(10000)
+	account := setupAccountWithBalances(t, h, largeSGT, largeNative)
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+	vaultBefore := h.CalcVaultBalance()
+
+	receipt := executeTransfer(t, h, account, dummyAddr, txValue)
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	vaultAfter := h.CalcVaultBalance()
+
+	// Vault increased by gas cost
+	vaultDiff := new(big.Int).Sub(vaultAfter, vaultBefore)
+	t.Require().Equal(0, vaultDiff.Cmp(gasCost), "vault balance diff should equal gas cost")
+
+	// SGT used for gas
+	expectedSGT := new(big.Int).Sub(preSGT, gasCost)
+	t.Require().Equal(0, expectedSGT.Cmp(postSGT), "SGT should be reduced by gas cost")
+
+	h.InvariantBalanceCheck(account.Address(), gasCost, txValue, preSGT, preNative, postSGT, true)
+}
+
+// TestSGT_PartialSGTGasPaymentAndNonZeroTxValueWithSufficientNativeBalanceSuccess verifies
+// partial SGT gas payment with a non-zero tx value.
+func TestSGT_PartialSGTGasPaymentAndNonZeroTxValueWithSufficientNativeBalanceSuccess(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	txValue := big.NewInt(10000)
+	account := setupAccountWithBalances(t, h, big.NewInt(1000), largeNative)
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+	vaultBefore := h.CalcVaultBalance()
+
+	receipt := executeTransfer(t, h, account, dummyAddr, txValue)
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	vaultAfter := h.CalcVaultBalance()
+
+	// Vault increased by gas cost
+	vaultDiff := new(big.Int).Sub(vaultAfter, vaultBefore)
+	t.Require().Equal(0, vaultDiff.Cmp(gasCost), "vault balance diff should equal gas cost")
+
+	// SGT fully spent
+	t.Require().Equal(0, postSGT.Sign(), "SGT should be fully spent")
+
+	h.InvariantBalanceCheck(account.Address(), gasCost, txValue, preSGT, preNative, postSGT, true)
+}
+
+// TestSGT_FullSGTInsufficientGasPaymentFail verifies that a transaction fails when
+// the account has only a small SGT balance and no native balance.
+func TestSGT_FullSGTInsufficientGasPaymentFail(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, new(big.Int).Set(smallBalance), big.NewInt(0))
+	assertTransferFails(t, account, dummyAddr, big.NewInt(0))
+}
+
+// TestSGT_FullNativeInsufficientGasPaymentFail verifies that a transaction fails when
+// the account has only a small native balance and no SGT balance.
+func TestSGT_FullNativeInsufficientGasPaymentFail(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, big.NewInt(0), new(big.Int).Set(smallBalance))
+	assertTransferFails(t, account, dummyAddr, big.NewInt(0))
+}
+
+// TestSGT_PartialSGTInsufficientGasPaymentFail verifies that a transaction fails
+// when the combined SGT and native balance is insufficient to cover gas.
+func TestSGT_PartialSGTInsufficientGasPaymentFail(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, new(big.Int).Set(smallBalance), new(big.Int).Set(smallBalance))
+	assertTransferFails(t, account, dummyAddr, big.NewInt(0))
+}
+
+// TestSGT_FullSGTGasPaymentAndNonZeroTxValueWithInsufficientNativeBalanceFail verifies
+// failure when SGT covers gas but native balance is insufficient to cover tx value.
+func TestSGT_FullSGTGasPaymentAndNonZeroTxValueWithInsufficientNativeBalanceFail(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, largeSGT, new(big.Int).Set(smallBalance))
+	txValue := new(big.Int).Add(smallBalance, big.NewInt(1))
+	assertTransferFails(t, account, dummyAddr, txValue)
+}
+
+// TestSGT_PartialSGTGasPaymentAndNonZeroTxValueWithInsufficientNativeBalanceFail verifies
+// failure when partial SGT covers some gas but native is insufficient for tx value after gas remainder.
+func TestSGT_PartialSGTGasPaymentAndNonZeroTxValueWithInsufficientNativeBalanceFail(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	account := setupAccountWithBalances(t, h, new(big.Int).Set(smallBalance), largeNative)
+	txValue := new(big.Int).Sub(largeNative, smallBalance)
+	assertTransferFails(t, account, dummyAddr, txValue)
+}
+
+// TestSGT_BalanceInvariant explicitly tests the balance invariant:
+// preSGT + preNative == postSGT + postNative + gasCost + txValue
+func TestSGT_BalanceInvariant(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	txValue := big.NewInt(42000)
+	account := setupAccountWithBalances(t, h, largeSGT, largeNative)
+
+	preSGT := h.GetSGTBalance(account.Address())
+	preNative := h.GetNativeBalance(account.Address())
+
+	receipt := executeTransfer(t, h, account, dummyAddr, txValue)
+	gasCost := CalcGasFee(receipt)
+
+	postSGT := h.GetSGTBalance(account.Address())
+	postNative := h.GetNativeBalance(account.Address())
+
+	preBal := new(big.Int).Add(preSGT, preNative)
+	postBal := new(big.Int).Add(postSGT, postNative)
+	postBal = postBal.Add(postBal, gasCost)
+	postBal = postBal.Add(postBal, txValue)
+
+	t.Require().Equal(0, preBal.Cmp(postBal),
+		"balance invariant: pre(%s) != post+gas+value(%s)", preBal, postBal)
+}
+
+// setupAccountWithBalances creates a fresh account with exact SGT and native balances.
+func setupAccountWithBalances(t devtest.T, h *SgtHelper, sgtDeposit, nativeDeposit *big.Int) *dsl.EOA {
+	setupGas := new(big.Int).Mul(big.NewInt(1), big.NewInt(1e18)) // 1 ETH for setup gas
+	totalNeeded := new(big.Int).Add(sgtDeposit, nativeDeposit)
+	totalNeeded = totalNeeded.Add(totalNeeded, setupGas)
+
+	funder := h.sys.FunderL2.NewFundedEOA(eth.WeiBig(totalNeeded))
+
+	// Create the test account (fresh, zero balances)
+	testAccount := h.sys.Wallet.NewEOA(h.sys.L2EL)
+
+	// Deposit SGT if needed (funder deposits to testAccount via batchDepositForAll)
+	if sgtDeposit.Sign() > 0 {
+		h.DepositSGT(funder, testAccount.Address(), sgtDeposit)
+	}
+
+	// Transfer native if needed
+	if nativeDeposit.Sign() > 0 {
+		funder.Transfer(testAccount.Address(), eth.WeiBig(nativeDeposit))
+	}
+
+	// Verify SGT balance
+	actualSGT := h.GetSGTBalance(testAccount.Address())
+	t.Require().Equal(0, sgtDeposit.Cmp(actualSGT),
+		"SGT deposit mismatch: got %s, want %s", actualSGT, sgtDeposit)
+
+	// Verify native balance
+	actualNative := h.GetNativeBalance(testAccount.Address())
+	t.Require().Equal(0, nativeDeposit.Cmp(actualNative),
+		"native deposit mismatch: got %s, want %s", actualNative, nativeDeposit)
+
+	return testAccount
+}
+
+// executeTransfer sends a native transfer from the account to the target.
+func executeTransfer(t devtest.T, h *SgtHelper, account *dsl.EOA, target common.Address, txValue *big.Int) *types.Receipt {
+	plannedTx := account.Transact(
+		account.PlanTransfer(target, eth.WeiBig(txValue)),
+	)
+	receipt, err := plannedTx.Included.Get()
+	t.Require().NoError(err, "failed to get receipt")
+	t.Require().Equal(uint64(1), receipt.Status, "tx should succeed")
+	return receipt
+}
+
+// assertTransferFails verifies that a transfer tx fails (e.g., insufficient funds).
+func assertTransferFails(t devtest.T, account *dsl.EOA, target common.Address, txValue *big.Int) {
+	tx := txplan.NewPlannedTx(
+		account.PlanTransfer(target, eth.WeiBig(txValue)),
+	)
+	_, err := tx.Success.Eval(t.Ctx())
+	t.Require().Error(err, "transaction should fail due to insufficient funds")
+}

--- a/op-acceptance-tests/tests/sgt/genesis_test.go
+++ b/op-acceptance-tests/tests/sgt/genesis_test.go
@@ -1,0 +1,50 @@
+package sgt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// TestSGT_GenesisDeployment verifies that the SGT contract is deployed at
+// genesis at the expected predeploy address.
+func TestSGT_GenesisDeployment(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	l2Client := sys.L2EL.Escape().L2EthClient()
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	// Check that there is code at the SGT predeploy address
+	code, err := l2Client.CodeAtHash(ctx, sgtAddr, sys.L2EL.BlockRefByNumber(0).Hash)
+	t.Require().NoError(err, "failed to get code at SGT address")
+	t.Require().Greater(len(code), 0, "SGT contract should have code at genesis")
+}
+
+// TestSGT_GenesisBalanceOfReturnsZero verifies that a fresh account has zero
+// SGT balance, confirming the contract is functional at genesis.
+func TestSGT_GenesisBalanceOfReturnsZero(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+
+	l2Client := sys.L2EL.Escape().L2EthClient()
+
+	ctx, cancel := context.WithTimeout(t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	// Query balanceOf for a random address at genesis; should return 0
+	data, err := balanceOfFunc.EncodeArgs(dummyAddr)
+	t.Require().NoError(err, "failed to encode balanceOf args")
+
+	out, err := l2Client.Call(ctx, ethereum.CallMsg{To: &sgtAddr, Data: data}, rpc.BlockNumber(0))
+	t.Require().NoError(err, "balanceOf call should succeed at genesis block")
+	t.Require().NotNil(out, "balanceOf should return data")
+}

--- a/op-acceptance-tests/tests/sgt/helper.go
+++ b/op-acceptance-tests/tests/sgt/helper.go
@@ -1,0 +1,158 @@
+package sgt
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/ethereum-optimism/optimism/op-core/predeploys"
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/dsl"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/txplan"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lmittmann/w3"
+)
+
+var (
+	sgtAddr   = predeploys.SoulGasTokenAddr
+	seqVault  = predeploys.SequencerFeeVaultAddr
+	baseVault = predeploys.BaseFeeVaultAddr
+	l1Vault   = predeploys.L1FeeVaultAddr
+	dummyAddr = common.Address{0xff, 0xff}
+
+	balanceOfFunc        = w3.MustNewFunc("balanceOf(address)", "uint256")
+	batchDepositSelector = common.FromHex("0x84e08810") // batchDepositForAll(address[],uint256)
+)
+
+// SgtHelper provides utilities for SGT acceptance tests.
+type SgtHelper struct {
+	t   devtest.T
+	sys *presets.Minimal
+}
+
+// NewSgtHelper creates a new SGT test helper.
+func NewSgtHelper(t devtest.T, sys *presets.Minimal) *SgtHelper {
+	return &SgtHelper{
+		t:   t,
+		sys: sys,
+	}
+}
+
+// GetSGTBalance returns the SGT balance of the given address.
+func (h *SgtHelper) GetSGTBalance(addr common.Address) *big.Int {
+	l2Client := h.sys.L2EL.Escape().L2EthClient()
+
+	ctx, cancel := context.WithTimeout(h.t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	data, err := balanceOfFunc.EncodeArgs(addr)
+	h.t.Require().NoError(err, "failed to encode balanceOf args")
+
+	out, err := l2Client.Call(ctx, ethereum.CallMsg{To: &sgtAddr, Data: data}, rpc.LatestBlockNumber)
+	h.t.Require().NoError(err, "failed to call balanceOf on SGT contract")
+
+	var balance *big.Int
+	err = balanceOfFunc.DecodeReturns(out, &balance)
+	h.t.Require().NoError(err, "failed to decode balanceOf return")
+
+	return balance
+}
+
+// GetNativeBalance returns the native (ETH) balance of the given address.
+func (h *SgtHelper) GetNativeBalance(addr common.Address) *big.Int {
+	l2Client := h.sys.L2EL.Escape().L2EthClient()
+
+	ctx, cancel := context.WithTimeout(h.t.Ctx(), 20*time.Second)
+	defer cancel()
+
+	balance, err := l2Client.BalanceAt(ctx, addr, nil)
+	h.t.Require().NoError(err, "failed to get native balance")
+
+	return balance
+}
+
+// DepositSGT deposits SGT to the target address using batchDepositForAll via a funder EOA.
+// The funder must have enough native balance to cover msg.value (= sgtAmount).
+func (h *SgtHelper) DepositSGT(funder *dsl.EOA, target common.Address, sgtAmount *big.Int) {
+	calldata := encodeBatchDepositForAll(target, sgtAmount)
+	funder.Transact(
+		funder.Plan(),
+		txplan.WithTo(&sgtAddr),
+		txplan.WithEth(sgtAmount),
+		txplan.WithData(calldata),
+		txplan.WithGasLimit(200000),
+	)
+}
+
+// encodeBatchDepositForAll ABI-encodes batchDepositForAll(address[], uint256).
+// Layout: selector(4) + offset(32) + value(32) + array_length(32) + address(32)
+func encodeBatchDepositForAll(target common.Address, value *big.Int) []byte {
+	data := make([]byte, 0, 4+32*4)
+	data = append(data, batchDepositSelector...)
+
+	// offset to dynamic array: 0x40 (64 bytes, after the value param)
+	offset := common.LeftPadBytes(big.NewInt(64).Bytes(), 32)
+	data = append(data, offset...)
+
+	// value (uint256)
+	valBytes := common.LeftPadBytes(value.Bytes(), 32)
+	data = append(data, valBytes...)
+
+	// array length = 1
+	lenBytes := common.LeftPadBytes(big.NewInt(1).Bytes(), 32)
+	data = append(data, lenBytes...)
+
+	// address element (left-padded to 32 bytes)
+	addrBytes := common.LeftPadBytes(target.Bytes(), 32)
+	data = append(data, addrBytes...)
+
+	return data
+}
+
+// CalcVaultBalance returns the sum of fee vault balances (sequencer + base + L1 fee vaults).
+func (h *SgtHelper) CalcVaultBalance() *big.Int {
+	seqBal := h.GetNativeBalance(seqVault)
+	baseBal := h.GetNativeBalance(baseVault)
+	l1Bal := h.GetNativeBalance(l1Vault)
+	total := new(big.Int).Add(seqBal, baseBal)
+	return total.Add(total, l1Bal)
+}
+
+// CalcGasFee computes the total gas cost from a receipt: effectiveGasPrice * gasUsed + L1Fee.
+func CalcGasFee(receipt *types.Receipt) *big.Int {
+	fees := new(big.Int).Mul(receipt.EffectiveGasPrice, big.NewInt(int64(receipt.GasUsed)))
+	fees = fees.Add(fees, receipt.L1Fee)
+	return fees
+}
+
+// InvariantBalanceCheck verifies: preSGT + preNative = postSGT + postNative + gasCost + txValue
+func (h *SgtHelper) InvariantBalanceCheck(
+	addr common.Address,
+	gasCost *big.Int,
+	txValue *big.Int,
+	preSGT *big.Int,
+	preNative *big.Int,
+	postSGT *big.Int,
+	sgtShouldChange bool,
+) {
+	if sgtShouldChange {
+		h.t.Require().NotEqual(0, preSGT.Cmp(postSGT), "SGT balance should have changed")
+	} else {
+		h.t.Require().Equal(0, preSGT.Cmp(postSGT), "SGT balance should not have changed")
+	}
+
+	postNative := h.GetNativeBalance(addr)
+	preBal := new(big.Int).Add(preSGT, preNative)
+	postBal := new(big.Int).Add(postSGT, postNative)
+	postBal = postBal.Add(postBal, gasCost)
+	postBal = postBal.Add(postBal, txValue)
+
+	h.t.Require().Equal(0, preBal.Cmp(postBal),
+		"balance invariant violated: pre(%s) != post(%s) + gas(%s) + value(%s)",
+		preBal, postBal, gasCost, txValue)
+}

--- a/op-acceptance-tests/tests/sgt/init_test.go
+++ b/op-acceptance-tests/tests/sgt/init_test.go
@@ -1,0 +1,19 @@
+package sgt
+
+import (
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+)
+
+// TestMain creates the test-setups for SGT E2E tests.
+//
+// SGT (Soul Gas Token) is enabled via genesis deployment.
+// The WithSGT preset configures the system to deploy the SGT contract
+// at address 0x4200000000000000000000000000000000000800 during genesis.
+func TestMain(m *testing.M) {
+	presets.DoMain(m,
+		presets.WithMinimal(),
+		presets.WithSGT(true, true), // Enable SGT with native backing
+	)
+}

--- a/op-acceptance-tests/tests/sgt/sgt_smoke_test.go
+++ b/op-acceptance-tests/tests/sgt/sgt_smoke_test.go
@@ -1,0 +1,62 @@
+package sgt
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum-optimism/optimism/op-devstack/devtest"
+	"github.com/ethereum-optimism/optimism/op-devstack/presets"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+)
+
+// TestSGT_SmokeNativeTransfer verifies that a simple native ETH transfer works
+// on an SGT-enabled chain. The sender pays gas (via SGT if it has SGT balance,
+// otherwise via native) and the recipient receives the correct amount.
+func TestSGT_SmokeNativeTransfer(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	sender := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+	recipient := sys.Wallet.NewEOA(sys.L2EL)
+
+	amount := eth.OneHundredthEther
+	beforeR := recipient.GetBalance()
+	beforeS := sender.GetBalance()
+
+	sender.Transfer(recipient.Address(), amount)
+
+	// Recipient should have received exactly the amount
+	recipient.WaitForBalance(beforeR.Add(amount))
+	afterR := recipient.GetBalance()
+	t.Require().Equal(beforeR.Add(amount), afterR, "recipient balance mismatch")
+
+	// Sender should have lost at least the amount (plus gas)
+	afterS := sender.GetBalance()
+	t.Require().True(beforeS.Sub(afterS).Gt(amount),
+		"sender must have paid more than the transfer amount (gas was charged)")
+
+	// SGT balance of sender should be 0 since we didn't deposit SGT
+	sgtBal := h.GetSGTBalance(sender.Address())
+	t.Require().Equal(0, sgtBal.Sign(), "sender SGT balance should be zero without deposit")
+}
+
+// TestSGT_SmokeBalanceQuery verifies that SGT balance can be queried for fresh accounts.
+func TestSGT_SmokeBalanceQuery(gt *testing.T) {
+	t := devtest.SerialT(gt)
+	sys := presets.NewMinimal(t)
+	h := NewSgtHelper(t, sys)
+
+	// A fresh EOA should have zero SGT balance
+	fresh := sys.Wallet.NewEOA(sys.L2EL)
+	bal := h.GetSGTBalance(fresh.Address())
+	t.Require().Equal(0, bal.Sign(), "fresh account should have zero SGT")
+
+	// After depositing, balance should be non-zero
+	funder := sys.FunderL2.NewFundedEOA(eth.Ether(1))
+	depositAmount := big.NewInt(50000)
+	h.DepositSGT(funder, fresh.Address(), depositAmount)
+
+	bal = h.GetSGTBalance(fresh.Address())
+	t.Require().Equal(0, depositAmount.Cmp(bal), "SGT balance should match deposit")
+}

--- a/op-devstack/presets/soulgas.go
+++ b/op-devstack/presets/soulgas.go
@@ -1,0 +1,14 @@
+package presets
+
+import (
+	"github.com/ethereum-optimism/optimism/op-devstack/stack"
+	"github.com/ethereum-optimism/optimism/op-devstack/sysgo"
+)
+
+// WithSGT configures the system to deploy the Soul Gas Token (SGT) contract.
+// enabled controls whether SGT is deployed; nativeBacked controls whether SGT is 1:1 backed by native token.
+func WithSGT(enabled bool, nativeBacked bool) stack.CommonOption {
+	return stack.MakeCommon(sysgo.WithDeployerOptions(
+		sysgo.WithSoulGasToken(enabled, nativeBacked),
+	))
+}

--- a/op-devstack/sysgo/deployer.go
+++ b/op-devstack/sysgo/deployer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/testreq"
 	"github.com/ethereum-optimism/optimism/op-supervisor/supervisor/backend/depset"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -93,6 +94,20 @@ func WithDAFootprintGasScalar(scalar uint16, l2IDs ...stack.L2NetworkID) Deploye
 			}) {
 				l2.WithDAFootprintGasScalar(scalar)
 			}
+		}
+	}
+}
+
+// WithSoulGasToken enables Soul Gas Token deployment for L2 networks.
+// If enabled is true, SGT contract will be deployed in genesis.
+// nativeBacked determines if SGT is 1:1 backed by native token.
+func WithSoulGasToken(enabled bool, nativeBacked bool) DeployerOption {
+	return func(p devtest.P, _ devkeys.Keys, builder intentbuilder.Builder) {
+		builder.WithGlobalOverride("deploySoulGasToken", enabled)
+		builder.WithGlobalOverride("isSoulBackedByNative", nativeBacked)
+		if enabled {
+			// Activate SGT at genesis (offset 0)
+			builder.WithGlobalOverride("soulGasTokenTimeOffset", hexutil.Uint64(0))
 		}
 	}
 }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -268,8 +268,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ccfe6d724ceabd5518350cfb34f17dd3a6c3cc33579eee94d98101d3a511ff"
+source = "git+https://github.com/blockchaindevsh/evm?branch=op-fork-0.27.2#e92f642d25c37d3b57b53dc4183b824c286b9da9"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8024,8 +8023,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c92b75162c2ed1661849fa51683b11254a5b661798360a2c24be918edafd40"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "auto_impl",
  "revm",
@@ -11368,6 +11366,7 @@ dependencies = [
  "reth-storage-errors",
  "revm",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -11468,6 +11467,7 @@ dependencies = [
  "futures",
  "futures-util",
  "humantime",
+ "jsonrpsee",
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types-engine",
@@ -11592,6 +11592,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-json-rpc",
+ "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
  "alloy-rlp",
@@ -12723,8 +12724,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2aabdebaa535b3575231a88d72b642897ae8106cf6b0d12eafc6bfdf50abfc7"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12742,8 +12742,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74d1e5c1eaa44d39d537f668bc5c3409dc01e5c8be954da6c83370bbdf006457"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,8 +12753,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "892ff3e6a566cf8d72ffb627fdced3becebbd9ba64089c25975b9b028af326a5"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12771,8 +12769,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f61cc6d23678c4840af895b19f8acfbbd546142ec8028b6526c53cc1c16c98"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12787,8 +12784,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "529528d0b05fe646be86223032c3e77aa8b05caa2a35447d538c55965956a511"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12801,8 +12797,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7bf93ac5b91347c057610c0d96e923db8c62807e03f036762d03e981feddc1d"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "auto_impl",
  "either",
@@ -12815,8 +12810,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd0e43e815a85eded249df886c4badec869195e70cdd808a13cfca2794622d2"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12834,8 +12828,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3ccad59db91ef93696536a0dbaf2f6f17cfe20d4d8843ae118edb7e97947ef"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "auto_impl",
  "either",
@@ -12872,8 +12865,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11406408597bc249392d39295831c4b641b3a6f5c471a7c41104a7a1e3564c07"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12885,8 +12877,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1285c848d240678bf69cb0f6179ff5a4aee6fc8e921d89708087197a0aff3"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12910,8 +12901,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba580c56a8ec824a64f8a1683577876c2e1dbe5247044199e9b881421ad5dcf9"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12922,8 +12912,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311720d4f0f239b041375e7ddafdbd20032a33b7bae718562ea188e188ed9fd3"
+source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8024,6 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12724,6 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12741,6 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "bitvec",
  "phf",
@@ -12751,6 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12766,6 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12780,6 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12792,6 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "auto_impl",
  "either",
@@ -12804,6 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12821,6 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "auto_impl",
  "either",
@@ -12857,6 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12868,6 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12891,6 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12901,6 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
+source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12725,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=e78df8a4f4066e5885c1a4500093eadfba83b80c#e78df8a4f4066e5885c1a4500093eadfba83b80c"
+source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -267,8 +267,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.27.2"
-source = "git+https://github.com/blockchaindevsh/evm?branch=op-fork-0.27.2#e92f642d25c37d3b57b53dc4183b824c286b9da9"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b991c370ce44e70a3a9e474087e3d65e42e66f967644ad729dc4cec09a21fd09"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8023,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12724,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12742,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "bitvec",
  "phf",
@@ -12753,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12769,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12784,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12797,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "either",
@@ -12810,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12828,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "either",
@@ -12865,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12877,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12901,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12912,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/blockchaindevsh/revm?branch=op-revm-sgt-support#79e76f2770e355ba007f6259d8f8b61a7b6ed5af"
+source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3579,7 +3579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5192,7 +5192,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "revm",
@@ -9007,7 +9007,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12725,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",
@@ -13294,7 +13294,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -14302,7 +14302,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -15033,7 +15033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12725,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=b1a98a95454867e9bd6a58d08e085b6e1c20df34#b1a98a95454867e9bd6a58d08e085b6e1c20df34"
+source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3277,7 +3277,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3579,7 +3579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5192,7 +5192,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7685,7 +7685,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9007,7 +9007,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9446,7 +9446,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9622,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9652,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9698,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9711,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9749,7 +9749,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9875,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10093,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "futures",
  "pin-project",
@@ -10115,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -10293,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "clap",
  "eyre",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10458,7 +10458,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10478,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10512,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10534,7 +10534,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10603,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -10635,7 +10635,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "serde",
  "serde_json",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "bytes",
  "futures",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "bindgen",
  "cc",
@@ -10732,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "futures",
  "metrics",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10753,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11066,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11128,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11152,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "bytes",
  "eyre",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11756,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11777,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11789,7 +11789,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11812,7 +11812,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -11845,7 +11845,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11879,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11924,7 +11924,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11953,7 +11953,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11969,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12059,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -12089,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -12130,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12154,7 +12154,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12228,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12276,7 +12276,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12290,7 +12290,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12306,7 +12306,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12356,7 +12356,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12383,7 +12383,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12397,7 +12397,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12417,7 +12417,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12456,7 +12456,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12473,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12491,7 +12491,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12507,7 +12507,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12517,7 +12517,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "clap",
  "eyre",
@@ -12536,7 +12536,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "clap",
  "eyre",
@@ -12554,7 +12554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12600,7 +12600,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12626,7 +12626,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12653,7 +12653,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12673,7 +12673,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12698,7 +12698,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12717,7 +12717,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
+source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
 dependencies = [
  "zstd",
 ]
@@ -13294,7 +13294,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14302,7 +14302,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15033,7 +15033,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
 dependencies = [
  "cc",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -15617,7 +15617,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8024,7 +8024,6 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12725,7 +12724,6 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12741,6 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12751,6 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12766,6 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12780,6 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12792,6 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12804,6 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12821,6 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12857,6 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12868,6 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12891,6 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12901,6 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3a6aa08522a25ef18f91f36ce97b9e5423dea2a3#3a6aa08522a25ef18f91f36ce97b9e5423dea2a3"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2222,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.5"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "auto_impl",
  "revm",
@@ -9446,7 +9446,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9622,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9652,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9698,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9711,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9749,7 +9749,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9875,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10093,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "futures",
  "pin-project",
@@ -10115,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -10293,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "clap",
  "eyre",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10458,7 +10458,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10478,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10512,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10534,7 +10534,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10603,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -10635,7 +10635,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "serde",
  "serde_json",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "bytes",
  "futures",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "bindgen",
  "cc",
@@ -10732,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "futures",
  "metrics",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10753,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11066,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11128,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11152,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "bytes",
  "eyre",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11756,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11777,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11789,7 +11789,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11812,7 +11812,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -11845,7 +11845,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11879,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11924,7 +11924,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11953,7 +11953,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11969,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12059,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -12089,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -12130,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12154,7 +12154,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12228,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12276,7 +12276,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12290,7 +12290,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12306,7 +12306,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12356,7 +12356,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12383,7 +12383,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12397,7 +12397,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12417,7 +12417,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12456,7 +12456,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12473,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12491,7 +12491,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12507,7 +12507,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12517,7 +12517,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "clap",
  "eyre",
@@ -12536,7 +12536,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "clap",
  "eyre",
@@ -12554,7 +12554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12600,7 +12600,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12626,7 +12626,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12653,7 +12653,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12673,7 +12673,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12698,7 +12698,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12717,7 +12717,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.0"
-source = "git+https://github.com/QuarkChain/reth?rev=4efc6c714#4efc6c7141d7eeb75f62336a662bdbf86f139954"
+source = "git+https://github.com/QuarkChain/reth?rev=543e421e1#543e421e1777f76e5cce43711b8fdf32c8ced145"
 dependencies = [
  "zstd",
 ]
@@ -12725,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=1e1294b3469c633dea07c5af5dbc92032dd5480f#1e1294b3469c633dea07c5af5dbc92032dd5480f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -9446,7 +9446,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9470,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9536,7 +9536,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9622,7 +9622,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9632,7 +9632,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9652,7 +9652,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9682,7 +9682,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9698,7 +9698,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9711,7 +9711,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9749,7 +9749,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9835,7 +9835,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9875,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9899,7 +9899,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9923,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10016,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10093,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "futures",
  "pin-project",
@@ -10115,7 +10115,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10172,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10200,7 +10200,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10215,7 +10215,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10253,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -10293,7 +10293,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "clap",
  "eyre",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10415,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10458,7 +10458,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10478,7 +10478,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10488,7 +10488,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10512,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10534,7 +10534,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10547,7 +10547,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10565,7 +10565,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10603,7 +10603,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-test-utils"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "eyre",
@@ -10635,7 +10635,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "serde",
  "serde_json",
@@ -10659,7 +10659,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "bytes",
  "futures",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -10723,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "bindgen",
  "cc",
@@ -10732,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "futures",
  "metrics",
@@ -10744,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10753,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "futures-util",
  "if-addrs 0.14.0",
@@ -10767,7 +10767,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10872,7 +10872,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10887,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -10918,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10942,7 +10942,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11066,7 +11066,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -11104,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11128,7 +11128,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11152,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "bytes",
  "eyre",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -11756,7 +11756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11777,7 +11777,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -11789,7 +11789,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11812,7 +11812,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-util"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -11832,7 +11832,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "once_cell",
@@ -11845,7 +11845,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11879,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11924,7 +11924,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11953,7 +11953,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11969,7 +11969,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -11982,7 +11982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12059,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eip7928",
  "alloy-eips",
@@ -12089,7 +12089,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -12130,7 +12130,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -12154,7 +12154,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -12228,7 +12228,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12276,7 +12276,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -12290,7 +12290,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12306,7 +12306,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12356,7 +12356,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12383,7 +12383,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -12397,7 +12397,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -12417,7 +12417,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -12432,7 +12432,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12456,7 +12456,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -12473,7 +12473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -12491,7 +12491,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12507,7 +12507,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -12517,7 +12517,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "clap",
  "eyre",
@@ -12536,7 +12536,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "clap",
  "eyre",
@@ -12554,7 +12554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12600,7 +12600,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -12626,7 +12626,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -12653,7 +12653,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -12673,7 +12673,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12698,7 +12698,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -12717,7 +12717,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.11.0"
-source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8bb066f0c7b015ff36b26c08"
+source = "git+https://github.com/QuarkChain/reth?rev=ceb057bc0#ceb057bc067591d5594a2c7697260e6f14acd49c"
 dependencies = [
  "zstd",
 ]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3277,7 +3277,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3579,7 +3579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5192,7 +5192,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7685,7 +7685,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "auto_impl",
  "revm",
@@ -9007,7 +9007,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12725,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
+source = "git+https://github.com/QuarkChain/revm?rev=cdab9774d7fd27ec30e8a02afad0f41b3d18194b#cdab9774d7fd27ec30e8a02afad0f41b3d18194b"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",
@@ -13294,7 +13294,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -14302,7 +14302,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15617,7 +15617,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "revm",
@@ -12725,7 +12725,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12743,7 +12743,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "bitvec",
  "phf",
@@ -12754,7 +12754,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12770,7 +12770,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12785,7 +12785,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -12798,7 +12798,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "either",
@@ -12811,7 +12811,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12829,7 +12829,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "auto_impl",
  "either",
@@ -12866,7 +12866,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12878,7 +12878,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12902,7 +12902,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12913,7 +12913,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/QuarkChain/revm?rev=3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca#3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca"
+source = "git+https://github.com/QuarkChain/revm?rev=5d00d0145ced62e3175bb1dd41aa0a5236a22fcc#5d00d0145ced62e3175bb1dd41aa0a5236a22fcc"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,16 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,16 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,16 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "b1a98a95454867e9bd6a58d08e085b6e1c20df34" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,17 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-bytecode = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-database = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-state = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-primitives = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-interpreter = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-context = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-handler = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-precompile = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-inspector = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-context-interface = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-revm-database-interface = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-op-revm = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
-alloy-evm = { git = "https://github.com/blockchaindevsh/evm", branch = "op-fork-0.27.2" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -307,78 +307,78 @@ alloy-op-evm = { version = "0.26.3", path = "alloy-op-evm/", default-features = 
 alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (from git rev 564ffa58 / main) ====================
-reth = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-chain-state = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-db-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-eth-wire = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-ethereum-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-exex = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-exex-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-execution-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-fs-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-network = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-node-events = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-payload-builder-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-payload-util = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-prune = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-revm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-rpc-engine-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-stages-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-storage-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.11.0", default-features = false }
+reth = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-basic-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-chain-state = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-chainspec = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-cli = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-cli-commands = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-cli-runner = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-cli-util = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-codecs = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-consensus = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-consensus-common = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-db = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-db-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-db-common = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-downloaders = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-e2e-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-engine-local = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-engine-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-errors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-eth-wire = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-ethereum-cli = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-ethereum-consensus = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-ethereum-forks = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-evm = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-exex = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-exex-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-execution-errors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-execution-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-fs-util = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-metrics = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-network = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-network-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-network-peers = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-node-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-node-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-node-core = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-node-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-node-events = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-node-metrics = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-payload-builder-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-payload-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-payload-util = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-payload-validator = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-primitives-traits = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-provider = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-prune = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-prune-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-revm = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-rpc = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-rpc-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-rpc-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-rpc-engine-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-rpc-eth-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-rpc-eth-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-stages = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-stages-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-static-file = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-static-file-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-storage-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-storage-errors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-tasks = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-tracing = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-transaction-pool = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-trie = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-trie-common = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth-trie-db = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
+reth-zstd-compressors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "34.0.0", default-features = false }
@@ -685,3 +685,4 @@ revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7
 revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
 revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
 op-revm = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,17 +672,17 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "cdab9774d7fd27ec30e8a02afad0f41b3d18194b" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,16 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "3a6aa08522a25ef18f91f36ce97b9e5423dea2a3" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -307,78 +307,78 @@ alloy-op-evm = { version = "0.26.3", path = "alloy-op-evm/", default-features = 
 alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (from git rev 564ffa58 / main) ====================
-reth = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-basic-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-chain-state = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-chainspec = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-cli = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-cli-commands = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-cli-runner = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-cli-util = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-codecs = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-consensus = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-consensus-common = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-db = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-db-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-db-common = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-downloaders = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-e2e-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-engine-local = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-engine-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-errors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-eth-wire = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-ethereum-cli = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-ethereum-consensus = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-ethereum-forks = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-evm = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-exex = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-exex-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-execution-errors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-execution-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-fs-util = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-metrics = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-network = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-network-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-network-peers = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-node-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-node-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-node-core = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-node-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-node-events = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-node-metrics = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-payload-builder-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-payload-primitives = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-payload-util = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-payload-validator = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-primitives-traits = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-provider = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-prune = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-prune-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-revm = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-rpc = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-rpc-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-rpc-builder = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-rpc-engine-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-rpc-eth-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-rpc-eth-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-stages = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-stages-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-static-file = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-static-file-types = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-storage-api = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-storage-errors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-tasks = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-tracing = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-transaction-pool = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-trie = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-trie-common = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
-reth-trie-db = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0" }
-reth-zstd-compressors = { git = "https://github.com/QuarkChain/reth", rev = "ceb057bc0", default-features = false }
+reth = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-basic-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-chain-state = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-chainspec = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-cli = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-cli-commands = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-cli-runner = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-cli-util = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-codecs = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-consensus = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-consensus-common = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-db = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-db-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-db-common = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-downloaders = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-e2e-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-engine-local = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-engine-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-errors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-eth-wire = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-ethereum-cli = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-ethereum-consensus = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-ethereum-forks = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-evm = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-exex = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-exex-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-execution-errors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-execution-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-fs-util = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-metrics = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-network = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-network-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-network-peers = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-node-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-node-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-node-core = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-node-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-node-events = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-node-metrics = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-payload-builder-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-payload-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-payload-util = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-payload-validator = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-primitives-traits = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-provider = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-prune = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-prune-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-revm = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-rpc = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-rpc-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-rpc-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-rpc-engine-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-rpc-eth-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-rpc-eth-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-stages = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-stages-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-static-file = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-static-file-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-storage-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-storage-errors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-tasks = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-tracing = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-transaction-pool = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-trie = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-trie-common = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth-trie-db = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
+reth-zstd-compressors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "34.0.0", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -670,3 +670,19 @@ op-alloy-rpc-types = { path = "op-alloy/crates/rpc-types" }
 op-alloy = { path = "op-alloy/crates/op-alloy" }
 # Duplicated by: alloy-evm (crates.io)
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
+
+# Forked revm with SGT support (based on revm 34.0.0)
+revm = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-bytecode = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-database = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-state = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-primitives = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-interpreter = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-context = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-handler = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-precompile = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-inspector = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-context-interface = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+revm-database-interface = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+op-revm = { git = "https://github.com/blockchaindevsh/revm", branch = "op-revm-sgt-support" }
+alloy-evm = { git = "https://github.com/blockchaindevsh/evm", branch = "op-fork-0.27.2" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,16 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "3f5854a11ac1cbcf8883a2ac7b19bbdfd2a036ca" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -672,16 +672,16 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "1744019b68540b3a6a041c72dbdfe3e93ff8b26d" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "e78df8a4f4066e5885c1a4500093eadfba83b80c" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -307,78 +307,78 @@ alloy-op-evm = { version = "0.26.3", path = "alloy-op-evm/", default-features = 
 alloy-op-hardforks = { version = "0.4.7", path = "alloy-op-hardforks/", default-features = false }
 
 # ==================== RETH CRATES (from git rev 564ffa58 / main) ====================
-reth = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-basic-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-chain-state = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-chainspec = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-cli = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-cli-commands = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-cli-runner = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-cli-util = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-codecs = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-consensus = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-consensus-common = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-db = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-db-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-db-common = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-downloaders = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-e2e-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-engine-local = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-engine-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-errors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-eth-wire = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-ethereum-cli = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-ethereum-consensus = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-ethereum-forks = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-evm = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-exex = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-exex-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-execution-errors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-execution-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-fs-util = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-metrics = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-network = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-network-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-network-peers = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-node-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-node-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-node-core = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-node-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-node-events = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-node-metrics = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-payload-builder-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-payload-primitives = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-payload-util = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-payload-validator = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-primitives-traits = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-provider = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-prune = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-prune-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-revm = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-rpc = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-rpc-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-rpc-builder = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-rpc-engine-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-rpc-eth-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-rpc-eth-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-rpc-server-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-stages = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-stages-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-static-file = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-static-file-types = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-storage-api = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-storage-errors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-tasks = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-tracing = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-transaction-pool = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-trie = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-trie-common = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
-reth-trie-db = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714" }
-reth-zstd-compressors = { git = "https://github.com/QuarkChain/reth", rev = "4efc6c714", default-features = false }
+reth = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-basic-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-chain-state = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-chainspec = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-cli = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-cli-commands = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-cli-runner = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-cli-util = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-codecs = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-consensus = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-consensus-common = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-db = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-db-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-db-common = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-downloaders = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-e2e-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-engine-local = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-engine-primitives = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-errors = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-eth-wire = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-ethereum-cli = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-ethereum-consensus = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-ethereum-forks = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-evm = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-exex = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-exex-test-utils = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-execution-errors = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-execution-types = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-fs-util = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-metrics = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-network = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-network-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-network-peers = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-node-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-node-builder = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-node-core = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-node-ethereum = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-node-events = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-node-metrics = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-payload-builder = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-payload-builder-primitives = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-payload-primitives = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-payload-util = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-payload-validator = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-primitives-traits = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-provider = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-prune = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-prune-types = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-revm = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-rpc = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-rpc-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-rpc-builder = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-rpc-engine-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-rpc-eth-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-rpc-eth-types = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-rpc-server-types = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-stages = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-stages-types = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-static-file = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-static-file-types = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-storage-api = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-storage-errors = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-tasks = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-tracing = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-transaction-pool = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-trie = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-trie-common = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
+reth-trie-db = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1" }
+reth-zstd-compressors = { git = "https://github.com/QuarkChain/reth", rev = "543e421e1", default-features = false }
 
 # ==================== REVM (latest: op-reth versions) ====================
 revm = { version = "34.0.0", default-features = false }
@@ -672,17 +672,17 @@ op-alloy = { path = "op-alloy/crates/op-alloy" }
 alloy-op-hardforks = { path = "alloy-op-hardforks/" }
 
 # Forked revm with SGT support (based on revm 34.0.0)
-revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-database = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-state = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-context = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
-op-revm = { git = "https://github.com/QuarkChain/revm", rev = "5d00d0145ced62e3175bb1dd41aa0a5236a22fcc" }
+revm = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-bytecode = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-database = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-state = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-primitives = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-interpreter = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-context = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-handler = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-precompile = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-inspector = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-context-interface = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+revm-database-interface = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
+op-revm = { git = "https://github.com/QuarkChain/revm", rev = "1e1294b3469c633dea07c5af5dbc92032dd5480f" }
 

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -55,8 +55,6 @@ pub struct OpBlockExecutionCtx {
     pub parent_beacon_block_root: Option<B256>,
     /// The block's extra data.
     pub extra_data: Bytes,
-    /// SGT configuration for this block.
-    pub sgt_config: crate::sgt::SgtConfig,
 }
 
 /// The result of executing an OP transaction.
@@ -462,16 +460,13 @@ where
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        mut evm: EvmF::Evm<&'a mut State<DB>, I>,
+        evm: EvmF::Evm<&'a mut State<DB>, I>,
         ctx: Self::ExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
         DB: Database + 'a,
         I: Inspector<EvmF::Context<&'a mut State<DB>>> + 'a,
     {
-        // Configure SGT settings for OP Stack
-        evm.configure_sgt(ctx.sgt_config.enabled, ctx.sgt_config.is_native_backed);
-
         OpBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
     }
 }

--- a/rust/alloy-op-evm/src/block/mod.rs
+++ b/rust/alloy-op-evm/src/block/mod.rs
@@ -55,6 +55,8 @@ pub struct OpBlockExecutionCtx {
     pub parent_beacon_block_root: Option<B256>,
     /// The block's extra data.
     pub extra_data: Bytes,
+    /// SGT configuration for this block.
+    pub sgt_config: crate::sgt::SgtConfig,
 }
 
 /// The result of executing an OP transaction.
@@ -460,13 +462,16 @@ where
 
     fn create_executor<'a, DB, I>(
         &'a self,
-        evm: EvmF::Evm<&'a mut State<DB>, I>,
+        mut evm: EvmF::Evm<&'a mut State<DB>, I>,
         ctx: Self::ExecutionCtx<'a>,
     ) -> impl BlockExecutorFor<'a, Self, DB, I>
     where
         DB: Database + 'a,
         I: Inspector<EvmF::Context<&'a mut State<DB>>> + 'a,
     {
+        // Configure SGT settings for OP Stack
+        evm.configure_sgt(ctx.sgt_config.enabled, ctx.sgt_config.is_native_backed);
+
         OpBlockExecutor::new(evm, ctx, &self.spec, &self.receipt_builder)
     }
 }

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -33,6 +33,9 @@ use revm::{
 pub mod block;
 pub use block::{OpBlockExecutionCtx, OpBlockExecutor, OpBlockExecutorFactory};
 
+pub mod sgt;
+pub use sgt::{SgtConfig, sgt_balance_slot, SGT_CONTRACT, SGT_BALANCE_SLOT};
+
 /// OP EVM implementation.
 ///
 /// This is a wrapper type around the `revm` evm with optional [`Inspector`] (tracing)
@@ -148,6 +151,21 @@ where
             &mut self.inner.0.inspector,
             &mut self.inner.0.precompiles,
         )
+    }
+
+    fn configure_sgt(&mut self, enabled: bool, is_native_backed: bool) {
+        OpEvm::configure_sgt(self, enabled, is_native_backed);
+    }
+}
+
+impl<DB: Database, I, P> OpEvm<DB, I, P> {
+    /// Set SGT configuration on the OP EVM context.
+    ///
+    /// This initializes the SGT configuration in L1BlockInfo before transaction execution.
+    /// The handler will read and preserve these values when fetching L1 block info from storage.
+    pub fn configure_sgt(&mut self, enabled: bool, is_native_backed: bool) {
+        self.ctx_mut().chain.sgt_enabled = enabled;
+        self.ctx_mut().chain.sgt_is_native_backed = is_native_backed;
     }
 }
 

--- a/rust/alloy-op-evm/src/lib.rs
+++ b/rust/alloy-op-evm/src/lib.rs
@@ -153,20 +153,6 @@ where
         )
     }
 
-    fn configure_sgt(&mut self, enabled: bool, is_native_backed: bool) {
-        OpEvm::configure_sgt(self, enabled, is_native_backed);
-    }
-}
-
-impl<DB: Database, I, P> OpEvm<DB, I, P> {
-    /// Set SGT configuration on the OP EVM context.
-    ///
-    /// This initializes the SGT configuration in L1BlockInfo before transaction execution.
-    /// The handler will read and preserve these values when fetching L1 block info from storage.
-    pub fn configure_sgt(&mut self, enabled: bool, is_native_backed: bool) {
-        self.ctx_mut().chain.sgt_enabled = enabled;
-        self.ctx_mut().chain.sgt_is_native_backed = is_native_backed;
-    }
 }
 
 /// Factory producing [`OpEvm`]s.

--- a/rust/alloy-op-evm/src/sgt.rs
+++ b/rust/alloy-op-evm/src/sgt.rs
@@ -1,0 +1,52 @@
+//! Soul Gas Token (SGT) support for OP Stack
+//!
+//! This module provides functionality for alternative gas payment using Soul Gas Tokens (SGT).
+//! SGT enables transactions to pay gas fees using tokens from a predeploy contract instead of
+//! native ETH.
+//!
+//! # Gas Payment Priority
+//!
+//! - **Deduction**: SGT first → Native balance second
+//! - **Refund**: Native balance first → SGT second (reverse order)
+//!
+//! # Two Modes
+//!
+//! 1. **Native-backed**: SGT 1:1 with native token (backed by native balance)
+//! 2. **Independent**: SGT is separate currency (minted/burned)
+
+use alloy_primitives::{Address, address};
+
+// Re-export from op-revm to avoid duplication
+pub use op_revm::sgt::sgt_balance_slot;
+
+/// SGT contract predeploy address
+pub const SGT_CONTRACT: Address =
+    address!("4200000000000000000000000000000000000800");
+
+/// Balance mapping base slot (must match Solidity contract)
+///
+/// The SGT contract stores balances in a mapping at slot 51:
+/// ```solidity
+/// mapping(address => uint256) public balances; // slot 51
+/// ```
+pub const SGT_BALANCE_SLOT: u64 = 51;
+
+/// SGT configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SgtConfig {
+    /// Whether SGT is enabled
+    pub enabled: bool,
+
+    /// Whether SGT is backed 1:1 by native token
+    pub is_native_backed: bool,
+}
+
+impl Default for SgtConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            is_native_backed: true,
+        }
+    }
+}
+

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -248,6 +248,11 @@ pub trait OpHardforks: EthereumHardforks {
         self.op_fork_activation(OpHardfork::Interop).active_at_timestamp(timestamp)
     }
 
+    /// Returns the SGT activation timestamp, if configured.
+    fn sgt_activation_timestamp(&self) -> Option<u64> {
+        None
+    }
+
     /// Returns `true` if Soul Gas Token (SGT) is active at given block timestamp.
     ///
     /// Default implementation returns `false`. Override in chain-specific implementations

--- a/rust/alloy-op-hardforks/src/lib.rs
+++ b/rust/alloy-op-hardforks/src/lib.rs
@@ -247,6 +247,21 @@ pub trait OpHardforks: EthereumHardforks {
     fn is_interop_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.op_fork_activation(OpHardfork::Interop).active_at_timestamp(timestamp)
     }
+
+    /// Returns `true` if Soul Gas Token (SGT) is active at given block timestamp.
+    ///
+    /// Default implementation returns `false`. Override in chain-specific implementations
+    /// (e.g., `OpChainSpec`) to enable SGT based on configuration.
+    fn is_sgt_active_at_timestamp(&self, _timestamp: u64) -> bool {
+        false
+    }
+
+    /// Returns whether SGT is backed 1:1 by native token.
+    ///
+    /// Default implementation returns `true` (conservative default).
+    fn is_sgt_native_backed(&self) -> bool {
+        true
+    }
 }
 
 /// A type allowing to configure activation [`ForkCondition`]s for a given list of

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -259,7 +259,6 @@ where
             parent_beacon_block_root: attrs.payload_attributes.parent_beacon_block_root,
             // This field is unused for individual block building jobs.
             extra_data: Default::default(),
-            sgt_config: Default::default(),
         };
         let executor = self.factory.create_executor(evm, ctx);
 

--- a/rust/kona/crates/proof/executor/src/builder/core.rs
+++ b/rust/kona/crates/proof/executor/src/builder/core.rs
@@ -259,6 +259,7 @@ where
             parent_beacon_block_root: attrs.payload_attributes.parent_beacon_block_root,
             // This field is unused for individual block building jobs.
             extra_data: Default::default(),
+            sgt_config: Default::default(),
         };
         let executor = self.factory.create_executor(evm, ctx);
 

--- a/rust/op-reth/crates/chainspec/src/base.rs
+++ b/rust/op-reth/crates/chainspec/src/base.rs
@@ -35,6 +35,8 @@ pub static BASE_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             ),
             ..Default::default()
         },
+        sgt_activation_timestamp: None,
+        sgt_is_native_backed: true,
     }
     .into()
 });

--- a/rust/op-reth/crates/chainspec/src/base_sepolia.rs
+++ b/rust/op-reth/crates/chainspec/src/base_sepolia.rs
@@ -36,6 +36,8 @@ pub static BASE_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             prune_delete_limit: 10000,
             ..Default::default()
         },
+        sgt_activation_timestamp: None,
+        sgt_is_native_backed: true,
     }
     .into()
 });

--- a/rust/op-reth/crates/chainspec/src/basefee.rs
+++ b/rust/op-reth/crates/chainspec/src/basefee.rs
@@ -100,6 +100,8 @@ mod tests {
                 genesis_header: base_sepolia_spec.genesis_header,
                 ..Default::default()
             },
+            sgt_activation_timestamp: None,
+            sgt_is_native_backed: true,
         })
     }
 

--- a/rust/op-reth/crates/chainspec/src/dev.rs
+++ b/rust/op-reth/crates/chainspec/src/dev.rs
@@ -29,6 +29,8 @@ pub static OP_DEV: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             base_fee_params: BaseFeeParamsKind::Constant(BaseFeeParams::ethereum()),
             ..Default::default()
         },
+        sgt_activation_timestamp: None,
+        sgt_is_native_backed: true,
     }
     .into()
 });

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -218,10 +218,13 @@ impl OpChainSpecBuilder {
         inner.genesis_header =
             SealedHeader::seal_slow(make_op_genesis_header(&inner.genesis, &inner.hardforks));
 
+        let (sgt_activation_timestamp, sgt_is_native_backed) =
+            parse_sgt_config(&inner.genesis);
+
         OpChainSpec {
             inner,
-            sgt_activation_timestamp: None,
-            sgt_is_native_backed: true,
+            sgt_activation_timestamp,
+            sgt_is_native_backed,
         }
     }
 }
@@ -236,6 +239,24 @@ pub struct OpChainSpec {
     pub sgt_activation_timestamp: Option<u64>,
     /// Whether SGT is backed by native (from config.optimism.isSoulBackedByNative)
     pub sgt_is_native_backed: bool,
+}
+
+/// Parse SGT config from genesis extra fields (config.optimism.soulGasTokenTime / isSoulBackedByNative).
+fn parse_sgt_config(genesis: &Genesis) -> (Option<u64>, bool) {
+    genesis
+        .config
+        .extra_fields
+        .get("optimism")
+        .and_then(|v| v.as_object())
+        .map(|obj| {
+            let timestamp = obj.get("soulGasTokenTime").and_then(|v| v.as_u64());
+            let native_backed = obj
+                .get("isSoulBackedByNative")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            (timestamp, native_backed)
+        })
+        .unwrap_or((None, true))
 }
 
 impl OpChainSpec {
@@ -447,20 +468,7 @@ impl From<Genesis> for OpChainSpec {
         let genesis_header = SealedHeader::seal_slow(make_op_genesis_header(&genesis, &hardforks));
 
         // Parse SGT config from optimism extra field (same as op-geth genesis format)
-        let (sgt_activation_timestamp, sgt_is_native_backed) = genesis
-            .config
-            .extra_fields
-            .get("optimism")
-            .and_then(|v| v.as_object())
-            .map(|obj| {
-                let timestamp = obj.get("soulGasTokenTime").and_then(|v| v.as_u64());
-                let native_backed = obj
-                    .get("isSoulBackedByNative")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(true);
-                (timestamp, native_backed)
-            })
-            .unwrap_or((None, true));
+        let (sgt_activation_timestamp, sgt_is_native_backed) = parse_sgt_config(&genesis);
 
         Self {
             inner: ChainSpec {

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -371,6 +371,10 @@ impl OpHardforks for OpChainSpec {
         self.fork(fork)
     }
 
+    fn sgt_activation_timestamp(&self) -> Option<u64> {
+        self.sgt_activation_timestamp
+    }
+
     fn is_sgt_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.sgt_activation_timestamp
             .map(|activation| timestamp >= activation)

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -494,7 +494,9 @@ impl From<Genesis> for OpChainSpec {
 
 impl From<ChainSpec> for OpChainSpec {
     fn from(value: ChainSpec) -> Self {
-        Self { inner: value, sgt_activation_timestamp: None, sgt_is_native_backed: true }
+        let (sgt_activation_timestamp, sgt_is_native_backed) =
+            parse_sgt_config(&value.genesis);
+        Self { inner: value, sgt_activation_timestamp, sgt_is_native_backed }
     }
 }
 

--- a/rust/op-reth/crates/chainspec/src/lib.rs
+++ b/rust/op-reth/crates/chainspec/src/lib.rs
@@ -63,7 +63,7 @@ use alloy_eips::eip7840::BlobParams;
 use alloy_genesis::Genesis;
 use alloy_hardforks::Hardfork;
 use alloy_primitives::{B256, U256};
-use derive_more::{Constructor, Deref, From, Into};
+use derive_more::{Deref, From};
 use reth_chainspec::{
     BaseFeeParams, BaseFeeParamsKind, ChainSpec, ChainSpecBuilder, DepositContract,
     DisplayHardforks, EthChainSpec, EthereumHardforks, ForkFilter, ForkId, Hardforks, Head,
@@ -218,18 +218,32 @@ impl OpChainSpecBuilder {
         inner.genesis_header =
             SealedHeader::seal_slow(make_op_genesis_header(&inner.genesis, &inner.hardforks));
 
-        OpChainSpec { inner }
+        OpChainSpec {
+            inner,
+            sgt_activation_timestamp: None,
+            sgt_is_native_backed: true,
+        }
     }
 }
 
 /// OP stack chain spec type.
-#[derive(Debug, Clone, Deref, Into, Constructor, PartialEq, Eq)]
+#[derive(Debug, Clone, Deref, PartialEq, Eq)]
 pub struct OpChainSpec {
     /// [`ChainSpec`].
+    #[deref]
     pub inner: ChainSpec,
+    /// SGT activation timestamp from genesis config.optimism.soulGasTokenTime
+    pub sgt_activation_timestamp: Option<u64>,
+    /// Whether SGT is backed by native (from config.optimism.isSoulBackedByNative)
+    pub sgt_is_native_backed: bool,
 }
 
 impl OpChainSpec {
+    /// Constructs a new [`OpChainSpec`] from the given inner [`ChainSpec`].
+    pub fn new(inner: ChainSpec) -> Self {
+        Self { inner, sgt_activation_timestamp: None, sgt_is_native_backed: true }
+    }
+
     /// Converts the given [`Genesis`] into a [`OpChainSpec`].
     pub fn from_genesis(genesis: Genesis) -> Self {
         genesis.into()
@@ -335,6 +349,16 @@ impl OpHardforks for OpChainSpec {
     fn op_fork_activation(&self, fork: OpHardfork) -> ForkCondition {
         self.fork(fork)
     }
+
+    fn is_sgt_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.sgt_activation_timestamp
+            .map(|activation| timestamp >= activation)
+            .unwrap_or(false)
+    }
+
+    fn is_sgt_native_backed(&self) -> bool {
+        self.sgt_is_native_backed
+    }
 }
 
 impl From<Genesis> for OpChainSpec {
@@ -422,6 +446,22 @@ impl From<Genesis> for OpChainSpec {
         let hardforks = ChainHardforks::new(ordered_hardforks);
         let genesis_header = SealedHeader::seal_slow(make_op_genesis_header(&genesis, &hardforks));
 
+        // Parse SGT config from optimism extra field (same as op-geth genesis format)
+        let (sgt_activation_timestamp, sgt_is_native_backed) = genesis
+            .config
+            .extra_fields
+            .get("optimism")
+            .and_then(|v| v.as_object())
+            .map(|obj| {
+                let timestamp = obj.get("soulGasTokenTime").and_then(|v| v.as_u64());
+                let native_backed = obj
+                    .get("isSoulBackedByNative")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                (timestamp, native_backed)
+            })
+            .unwrap_or((None, true));
+
         Self {
             inner: ChainSpec {
                 chain: genesis.config.chain_id.into(),
@@ -434,13 +474,21 @@ impl From<Genesis> for OpChainSpec {
                 base_fee_params: optimism_genesis_info.base_fee_params,
                 ..Default::default()
             },
+            sgt_activation_timestamp,
+            sgt_is_native_backed,
         }
     }
 }
 
 impl From<ChainSpec> for OpChainSpec {
     fn from(value: ChainSpec) -> Self {
-        Self { inner: value }
+        Self { inner: value, sgt_activation_timestamp: None, sgt_is_native_backed: true }
+    }
+}
+
+impl From<OpChainSpec> for ChainSpec {
+    fn from(value: OpChainSpec) -> Self {
+        value.inner
     }
 }
 

--- a/rust/op-reth/crates/chainspec/src/op.rs
+++ b/rust/op-reth/crates/chainspec/src/op.rs
@@ -36,6 +36,8 @@ pub static OP_MAINNET: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             prune_delete_limit: 10000,
             ..Default::default()
         },
+        sgt_activation_timestamp: None,
+        sgt_is_native_backed: true,
     }
     .into()
 });

--- a/rust/op-reth/crates/chainspec/src/op_sepolia.rs
+++ b/rust/op-reth/crates/chainspec/src/op_sepolia.rs
@@ -34,6 +34,8 @@ pub static OP_SEPOLIA: LazyLock<Arc<OpChainSpec>> = LazyLock::new(|| {
             prune_delete_limit: 10000,
             ..Default::default()
         },
+        sgt_activation_timestamp: None,
+        sgt_is_native_backed: true,
     }
     .into()
 });

--- a/rust/op-reth/crates/consensus/src/validation/mod.rs
+++ b/rust/op-reth/crates/consensus/src/validation/mod.rs
@@ -237,6 +237,8 @@ mod tests {
                 prune_delete_limit: 10000,
                 ..Default::default()
             },
+            sgt_activation_timestamp: None,
+            sgt_is_native_backed: true,
         })
     }
 

--- a/rust/op-reth/crates/evm/Cargo.toml
+++ b/rust/op-reth/crates/evm/Cargo.toml
@@ -42,6 +42,7 @@ op-revm.workspace = true
 
 # misc
 thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 reth-evm = { workspace = true, features = ["test-utils"] }

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -22,6 +22,7 @@ use reth_chainspec::EthChainSpec;
 use reth_evm::{
     ConfigureEvm, EvmEnv, TransactionEnv, eth::NextEvmEnvAttributes, precompiles::PrecompilesMap,
 };
+use tracing::debug;
 use reth_optimism_chainspec::OpChainSpec;
 use reth_optimism_forks::OpHardforks;
 use reth_optimism_primitives::{DepositReceipt, OpPrimitives};
@@ -120,6 +121,19 @@ where
     pub const fn chain_spec(&self) -> &Arc<ChainSpec> {
         self.executor_factory.spec()
     }
+
+    /// Extract SGT configuration for a given timestamp.
+    fn extract_sgt_config(&self, timestamp: u64) -> alloy_op_evm::sgt::SgtConfig {
+        let chain_spec = self.chain_spec();
+        let enabled = chain_spec.is_sgt_active_at_timestamp(timestamp);
+        let is_native_backed = chain_spec.is_sgt_native_backed();
+
+        if enabled {
+            debug!(target: "evm", timestamp, is_native_backed, "SGT enabled for block");
+        }
+
+        alloy_op_evm::sgt::SgtConfig { enabled, is_native_backed }
+    }
 }
 
 impl<ChainSpec, N, R, EvmF> ConfigureEvm for OpEvmConfig<ChainSpec, N, R, EvmF>
@@ -186,10 +200,14 @@ where
         &self,
         block: &'_ SealedBlock<N::Block>,
     ) -> Result<OpBlockExecutionCtx, Self::Error> {
+        let sgt_config =
+            self.extract_sgt_config(block.header().timestamp());
+
         Ok(OpBlockExecutionCtx {
             parent_hash: block.header().parent_hash(),
             parent_beacon_block_root: block.header().parent_beacon_block_root(),
             extra_data: block.header().extra_data().clone(),
+            sgt_config,
         })
     }
 
@@ -198,10 +216,13 @@ where
         parent: &SealedHeader<N::BlockHeader>,
         attributes: Self::NextBlockEnvCtx,
     ) -> Result<OpBlockExecutionCtx, Self::Error> {
+        let sgt_config = self.extract_sgt_config(attributes.timestamp);
+
         Ok(OpBlockExecutionCtx {
             parent_hash: parent.hash(),
             parent_beacon_block_root: attributes.parent_beacon_block_root,
             extra_data: attributes.extra_data,
+            sgt_config,
         })
     }
 }
@@ -263,10 +284,14 @@ where
         &self,
         payload: &'a OpExecutionData,
     ) -> Result<ExecutionCtxFor<'a, Self>, Self::Error> {
+        let sgt_config =
+            self.extract_sgt_config(payload.payload.timestamp());
+
         Ok(OpBlockExecutionCtx {
             parent_hash: payload.parent_hash(),
             parent_beacon_block_root: payload.sidecar.parent_beacon_block_root(),
             extra_data: payload.payload.as_v1().extra_data.clone(),
+            sgt_config,
         })
     }
 
@@ -337,7 +362,7 @@ mod tests {
         // Use the `OpEvmConfig` to create the `cfg_env` and `block_env` based on the ChainSpec,
         // Header, and total difficulty
         let EvmEnv { cfg_env, .. } =
-            OpEvmConfig::optimism(Arc::new(OpChainSpec { inner: chain_spec.clone() }))
+            OpEvmConfig::optimism(Arc::new(OpChainSpec::new(chain_spec.clone())))
                 .evm_env(&header)
                 .unwrap();
 

--- a/rust/op-reth/crates/evm/src/lib.rs
+++ b/rust/op-reth/crates/evm/src/lib.rs
@@ -174,7 +174,11 @@ where
     }
 
     fn evm_env(&self, header: &Header) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        Ok(EvmEnv::for_op_block(header, self.chain_spec(), self.chain_spec().chain().id()))
+        let mut env = EvmEnv::for_op_block(header, self.chain_spec(), self.chain_spec().chain().id());
+        let sgt_config = self.extract_sgt_config(header.timestamp());
+        env.cfg_env.sgt_enabled = sgt_config.enabled;
+        env.cfg_env.sgt_is_native_backed = sgt_config.is_native_backed;
+        Ok(env)
     }
 
     fn next_evm_env(
@@ -182,7 +186,7 @@ where
         parent: &Header,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnv<OpSpecId>, Self::Error> {
-        Ok(EvmEnv::for_op_next_block(
+        let mut env = EvmEnv::for_op_next_block(
             parent,
             NextEvmEnvAttributes {
                 timestamp: attributes.timestamp,
@@ -193,21 +197,21 @@ where
             self.chain_spec().next_block_base_fee(parent, attributes.timestamp).unwrap_or_default(),
             self.chain_spec(),
             self.chain_spec().chain().id(),
-        ))
+        );
+        let sgt_config = self.extract_sgt_config(attributes.timestamp);
+        env.cfg_env.sgt_enabled = sgt_config.enabled;
+        env.cfg_env.sgt_is_native_backed = sgt_config.is_native_backed;
+        Ok(env)
     }
 
     fn context_for_block(
         &self,
         block: &'_ SealedBlock<N::Block>,
     ) -> Result<OpBlockExecutionCtx, Self::Error> {
-        let sgt_config =
-            self.extract_sgt_config(block.header().timestamp());
-
         Ok(OpBlockExecutionCtx {
             parent_hash: block.header().parent_hash(),
             parent_beacon_block_root: block.header().parent_beacon_block_root(),
             extra_data: block.header().extra_data().clone(),
-            sgt_config,
         })
     }
 
@@ -216,13 +220,10 @@ where
         parent: &SealedHeader<N::BlockHeader>,
         attributes: Self::NextBlockEnvCtx,
     ) -> Result<OpBlockExecutionCtx, Self::Error> {
-        let sgt_config = self.extract_sgt_config(attributes.timestamp);
-
         Ok(OpBlockExecutionCtx {
             parent_hash: parent.hash(),
             parent_beacon_block_root: attributes.parent_beacon_block_root,
             extra_data: attributes.extra_data,
-            sgt_config,
         })
     }
 }
@@ -251,9 +252,12 @@ where
 
         let spec = revm_spec_by_timestamp_after_bedrock(self.chain_spec(), timestamp);
 
-        let cfg_env = CfgEnv::new()
+        let sgt_config = self.extract_sgt_config(timestamp);
+        let mut cfg_env = CfgEnv::new()
             .with_chain_id(self.chain_spec().chain().id())
             .with_spec_and_mainnet_gas_params(spec);
+        cfg_env.sgt_enabled = sgt_config.enabled;
+        cfg_env.sgt_is_native_backed = sgt_config.is_native_backed;
 
         let blob_excess_gas_and_price = spec
             .into_eth_spec()
@@ -284,14 +288,10 @@ where
         &self,
         payload: &'a OpExecutionData,
     ) -> Result<ExecutionCtxFor<'a, Self>, Self::Error> {
-        let sgt_config =
-            self.extract_sgt_config(payload.payload.timestamp());
-
         Ok(OpBlockExecutionCtx {
             parent_hash: payload.parent_hash(),
             parent_beacon_block_root: payload.sidecar.parent_beacon_block_root(),
             extra_data: payload.payload.as_v1().extra_data.clone(),
-            sgt_config,
         })
     }
 

--- a/rust/op-reth/crates/node/Cargo.toml
+++ b/rust/op-reth/crates/node/Cargo.toml
@@ -80,6 +80,7 @@ url.workspace = true
 humantime.workspace = true
 futures-util.workspace = true
 tracing.workspace = true
+jsonrpsee = { workspace = true, features = ["server"] }
 
 # test-utils dependencies
 reth-e2e-test-utils = { workspace = true, optional = true }

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -153,7 +153,7 @@ pub struct RollupArgs {
     pub http_sgt_addr: Option<String>,
 
     /// HTTP server port for SGT-enabled eth_getBalance endpoint
-    #[arg(long = "http.sgt.port", value_name = "SGT_HTTP_PORT", default_value_t = 8546)]
+    #[arg(long = "http.sgt.port", value_name = "SGT_HTTP_PORT", default_value_t = 8645)]
     pub http_sgt_port: u16,
 }
 
@@ -178,7 +178,7 @@ impl Default for RollupArgs {
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
             http_sgt_addr: None,
-            http_sgt_port: 8546,
+            http_sgt_port: 8645,
         }
     }
 }

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -8,6 +8,9 @@ use reth_optimism_txpool::supervisor::DEFAULT_SUPERVISOR_URL;
 use std::{path::PathBuf, time::Duration};
 use url::Url;
 
+/// Default port for the SGT HTTP RPC server.
+pub const DEFAULT_SGT_HTTP_PORT: u16 = 8645;
+
 /// Parameters for rollup configuration
 #[derive(Debug, Clone, PartialEq, Eq, clap::Args)]
 #[command(next_help_heading = "Rollup")]
@@ -153,7 +156,7 @@ pub struct RollupArgs {
     pub http_sgt_addr: Option<String>,
 
     /// HTTP server port for SGT-enabled eth_getBalance endpoint
-    #[arg(long = "http.sgt.port", value_name = "SGT_HTTP_PORT", default_value_t = 8645)]
+    #[arg(long = "http.sgt.port", value_name = "SGT_HTTP_PORT", default_value_t = DEFAULT_SGT_HTTP_PORT)]
     pub http_sgt_port: u16,
 }
 
@@ -178,7 +181,7 @@ impl Default for RollupArgs {
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
             http_sgt_addr: None,
-            http_sgt_port: 8645,
+            http_sgt_port: DEFAULT_SGT_HTTP_PORT,
         }
     }
 }

--- a/rust/op-reth/crates/node/src/args.rs
+++ b/rust/op-reth/crates/node/src/args.rs
@@ -144,6 +144,17 @@ pub struct RollupArgs {
         default_value_t = 0
     )]
     pub proofs_history_verification_interval: u64,
+
+    /// HTTP server address for SGT-enabled eth_getBalance endpoint
+    ///
+    /// When set, starts a second HTTP RPC server that returns native + SGT
+    /// combined balance for eth_getBalance calls.
+    #[arg(long = "http.sgt.addr", value_name = "SGT_HTTP_ADDR")]
+    pub http_sgt_addr: Option<String>,
+
+    /// HTTP server port for SGT-enabled eth_getBalance endpoint
+    #[arg(long = "http.sgt.port", value_name = "SGT_HTTP_PORT", default_value_t = 8546)]
+    pub http_sgt_port: u16,
 }
 
 impl Default for RollupArgs {
@@ -166,6 +177,8 @@ impl Default for RollupArgs {
             proofs_history_window: 1_296_000,
             proofs_history_prune_interval: Duration::from_secs(15),
             proofs_history_verification_interval: 0,
+            http_sgt_addr: None,
+            http_sgt_port: 8546,
         }
     }
 }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -667,20 +667,18 @@ where
                     module.merge(sgt_eth_api.into_rpc())
                         .map_err(|e| eyre::eyre!("Failed to merge SGT eth RPC methods: {}", e))?;
 
-                    let socket_for_log = socket;
+                    // Bind eagerly so failures surface at node startup.
+                    let listener = std::net::TcpListener::bind(socket)
+                        .map_err(|e| eyre::eyre!("Failed to bind SGT HTTP server on {}: {}", socket, e))?;
+                    let sgt_server = jsonrpsee::server::ServerBuilder::default()
+                        .build_from_tcp(listener)
+                        .map_err(|e| eyre::eyre!("Failed to build SGT HTTP server: {}", e))?;
+
+                    info!(target: "reth::cli", sgt_addr = %socket, "SGT HTTP RPC server started");
                     tokio::spawn(async move {
-                        match jsonrpsee::server::ServerBuilder::default().build(socket).await {
-                            Ok(server) => {
-                                info!(target: "reth::cli", %socket_for_log, "SGT HTTP RPC server started");
-                                let handle = server.start(module);
-                                handle.stopped().await;
-                                info!(target: "reth::cli", "SGT HTTP RPC server stopped");
-                            }
-                            Err(e) => {
-                                tracing::error!(target: "reth::cli", %socket_for_log, error = %e,
-                                               "Failed to start SGT HTTP server");
-                            }
-                        }
+                        let handle = sgt_server.start(module);
+                        handle.stopped().await;
+                        info!(target: "reth::cli", "SGT HTTP RPC server stopped");
                     });
                 }
 

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1118,6 +1118,7 @@ where
             transaction_pool.set_additional_balance_provider(std::sync::Arc::new(
                 move |addr| {
                     reth_optimism_rpc::eth::sgt::read_sgt_balance_from_provider(&client, addr)
+                        .map_err(|e| Box::new(e) as Box<dyn core::error::Error + Send + Sync>)
                 },
             ));
         }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1111,6 +1111,17 @@ where
             .with_validator(validator)
             .build_and_spawn_maintenance_task(blob_store, final_pool_config)?;
 
+        // When SGT is configured, provide the pool with an additional balance provider
+        // so that pool maintenance uses native + SGT for the ENOUGH_BALANCE check.
+        if ctx.chain_spec().sgt_activation_timestamp().is_some() {
+            let client = ctx.provider().clone();
+            transaction_pool.set_additional_balance_provider(std::sync::Arc::new(
+                move |addr| {
+                    reth_optimism_rpc::eth::sgt::read_sgt_balance_from_provider(&client, addr)
+                },
+            ));
+        }
+
         info!(target: "reth::cli", "Transaction pool initialized");
         debug!(target: "reth::cli", "Spawned txpool maintenance task");
 

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -195,6 +195,7 @@ impl OpNode {
             .with_historical_rpc(self.args.historical_rpc.clone())
             .with_flashblocks(self.args.flashblocks_url.clone())
             .with_flashblock_consensus(self.args.flashblock_consensus)
+            .with_sgt_http(self.args.http_sgt_addr.clone(), self.args.http_sgt_port)
     }
 
     /// Instantiates the [`ProviderFactoryBuilder`] for an opstack node.
@@ -323,6 +324,10 @@ pub struct OpAddOns<
     /// Enable transaction conditionals.
     enable_tx_conditional: bool,
     min_suggested_priority_fee: u64,
+    /// HTTP server address for SGT-enabled eth_getBalance endpoint
+    http_sgt_addr: Option<String>,
+    /// HTTP server port for SGT-enabled eth_getBalance endpoint
+    http_sgt_port: u16,
 }
 
 impl<N, EthB, PVB, EB, EVB, RpcMiddleware> OpAddOns<N, EthB, PVB, EB, EVB, RpcMiddleware>
@@ -341,6 +346,8 @@ where
         historical_rpc: Option<String>,
         enable_tx_conditional: bool,
         min_suggested_priority_fee: u64,
+        http_sgt_addr: Option<String>,
+        http_sgt_port: u16,
     ) -> Self {
         Self {
             rpc_add_ons,
@@ -351,6 +358,8 @@ where
             historical_rpc,
             enable_tx_conditional,
             min_suggested_priority_fee,
+            http_sgt_addr,
+            http_sgt_port,
         }
     }
 }
@@ -402,6 +411,8 @@ where
             historical_rpc,
             enable_tx_conditional,
             min_suggested_priority_fee,
+            http_sgt_addr,
+            http_sgt_port,
             ..
         } = self;
         OpAddOns::new(
@@ -413,6 +424,8 @@ where
             historical_rpc,
             enable_tx_conditional,
             min_suggested_priority_fee,
+            http_sgt_addr,
+            http_sgt_port,
         )
     }
 
@@ -430,6 +443,8 @@ where
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
+            http_sgt_addr,
+            http_sgt_port,
             ..
         } = self;
         OpAddOns::new(
@@ -441,6 +456,8 @@ where
             historical_rpc,
             enable_tx_conditional,
             min_suggested_priority_fee,
+            http_sgt_addr,
+            http_sgt_port,
         )
     }
 
@@ -461,6 +478,8 @@ where
             enable_tx_conditional,
             min_suggested_priority_fee,
             historical_rpc,
+            http_sgt_addr,
+            http_sgt_port,
             ..
         } = self;
         OpAddOns::new(
@@ -472,6 +491,8 @@ where
             historical_rpc,
             enable_tx_conditional,
             min_suggested_priority_fee,
+            http_sgt_addr,
+            http_sgt_port,
         )
     }
 
@@ -515,6 +536,7 @@ where
             Pool: TransactionPool<Transaction: OpPooledTx>,
         >,
     EthB: EthApiBuilder<N>,
+    EthB::EthApi: reth_optimism_rpc::EthApiWithSgtMode,
     PVB: Send,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -535,6 +557,8 @@ where
             sequencer_headers,
             enable_tx_conditional,
             historical_rpc,
+            http_sgt_addr,
+            http_sgt_port,
             ..
         } = self;
 
@@ -585,6 +609,8 @@ where
             ctx.node.provider().clone(),
         );
 
+        let sgt_config = http_sgt_addr.map(|addr| (addr, http_sgt_port));
+
         rpc_add_ons
             .launch_add_ons_with(ctx, move |container| {
                 let reth_node_builder::rpc::RpcModuleContainer { modules, auth_module, registry } =
@@ -619,6 +645,43 @@ where
                     )?;
                 }
 
+                // Spawn SGT HTTP server if configured
+                if let Some((sgt_addr, sgt_port)) = sgt_config {
+                    use reth_rpc_api::EthApiServer;
+                    use jsonrpsee::RpcModule;
+                    use reth_optimism_rpc::EthApiWithSgtMode;
+
+                    info!(target: "reth::cli", sgt_addr = %sgt_addr, sgt_port = %sgt_port,
+                          "Starting SGT HTTP server on separate port");
+
+                    let socket: std::net::SocketAddr = format!("{}:{}", sgt_addr, sgt_port)
+                        .parse()
+                        .map_err(|e| eyre::eyre!("Invalid SGT socket address: {}", e))?;
+
+                    let standard_eth_api = registry.eth_api();
+                    let sgt_eth_api = standard_eth_api.clone_with_sgt_mode(true);
+
+                    let mut module = RpcModule::new(());
+                    module.merge(sgt_eth_api.into_rpc())
+                        .map_err(|e| eyre::eyre!("Failed to merge SGT eth RPC methods: {}", e))?;
+
+                    let socket_for_log = socket;
+                    tokio::spawn(async move {
+                        match jsonrpsee::server::ServerBuilder::default().build(socket).await {
+                            Ok(server) => {
+                                info!(target: "reth::cli", %socket_for_log, "SGT HTTP RPC server started");
+                                let handle = server.start(module);
+                                handle.stopped().await;
+                                info!(target: "reth::cli", "SGT HTTP RPC server stopped");
+                            }
+                            Err(e) => {
+                                tracing::error!(target: "reth::cli", %socket_for_log, error = %e,
+                                               "Failed to start SGT HTTP server");
+                            }
+                        }
+                    });
+                }
+
                 Ok(())
             })
             .await
@@ -644,6 +707,7 @@ where
         >,
     <<N as FullNodeComponents>::Pool as TransactionPool>::Transaction: OpPooledTx,
     EthB: EthApiBuilder<N>,
+    EthB::EthApi: reth_optimism_rpc::EthApiWithSgtMode,
     PVB: PayloadValidatorBuilder<N>,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -662,6 +726,7 @@ impl<N, EthB, PVB, EB, EVB, RpcMiddleware> EngineValidatorAddOn<N>
 where
     N: FullNodeComponents,
     EthB: EthApiBuilder<N>,
+    EthB::EthApi: reth_optimism_rpc::EthApiWithSgtMode,
     PVB: Send,
     EB: EngineApiBuilder<N>,
     EVB: EngineValidatorBuilder<N>,
@@ -703,6 +768,10 @@ pub struct OpAddOnsBuilder<NetworkT, RpcMiddleware = Identity> {
     flashblocks_url: Option<Url>,
     /// Enable flashblock consensus client to drive chain forward.
     flashblock_consensus: bool,
+    /// HTTP server address for SGT-enabled eth_getBalance endpoint
+    http_sgt_addr: Option<String>,
+    /// HTTP server port for SGT-enabled eth_getBalance endpoint
+    http_sgt_port: u16,
 }
 
 impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
@@ -720,6 +789,8 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             tokio_runtime: None,
             flashblocks_url: None,
             flashblock_consensus: false,
+            http_sgt_addr: None,
+            http_sgt_port: 8546,
         }
     }
 }
@@ -789,6 +860,8 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             _nt,
             flashblocks_url,
             flashblock_consensus,
+            http_sgt_addr,
+            http_sgt_port,
             ..
         } = self;
         OpAddOnsBuilder {
@@ -804,6 +877,8 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             tokio_runtime,
             flashblocks_url,
             flashblock_consensus,
+            http_sgt_addr,
+            http_sgt_port,
         }
     }
 
@@ -816,6 +891,13 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
     /// With a flashblock consensus client to drive chain forward.
     pub const fn with_flashblock_consensus(mut self, flashblock_consensus: bool) -> Self {
         self.flashblock_consensus = flashblock_consensus;
+        self
+    }
+
+    /// Configure the SGT HTTP server address and port.
+    pub fn with_sgt_http(mut self, addr: Option<String>, port: u16) -> Self {
+        self.http_sgt_addr = addr;
+        self.http_sgt_port = port;
         self
     }
 }
@@ -844,6 +926,8 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             tokio_runtime,
             flashblocks_url,
             flashblock_consensus,
+            http_sgt_addr,
+            http_sgt_port,
             ..
         } = self;
 
@@ -868,6 +952,8 @@ impl<NetworkT, RpcMiddleware> OpAddOnsBuilder<NetworkT, RpcMiddleware> {
             historical_rpc,
             enable_tx_conditional,
             min_suggested_priority_fee,
+            http_sgt_addr,
+            http_sgt_port,
         )
     }
 }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -790,7 +790,7 @@ impl<NetworkT> Default for OpAddOnsBuilder<NetworkT> {
             flashblocks_url: None,
             flashblock_consensus: false,
             http_sgt_addr: None,
-            http_sgt_port: 8546,
+            http_sgt_port: crate::args::DEFAULT_SGT_HTTP_PORT,
         }
     }
 }

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -610,6 +610,7 @@ where
         );
 
         let sgt_config = http_sgt_addr.map(|addr| (addr, http_sgt_port));
+        let sgt_activation_timestamp = ctx.node.provider().chain_spec().sgt_activation_timestamp();
 
         rpc_add_ons
             .launch_add_ons_with(ctx, move |container| {
@@ -659,7 +660,8 @@ where
                         .map_err(|e| eyre::eyre!("Invalid SGT socket address: {}", e))?;
 
                     let standard_eth_api = registry.eth_api();
-                    let sgt_eth_api = standard_eth_api.clone_with_sgt_mode(true);
+                    let mut sgt_eth_api = standard_eth_api.clone_with_sgt_mode(true);
+                    sgt_eth_api.set_sgt_activation_timestamp(sgt_activation_timestamp);
 
                     let mut module = RpcModule::new(());
                     module.merge(sgt_eth_api.into_rpc())

--- a/rust/op-reth/crates/node/src/node.rs
+++ b/rust/op-reth/crates/node/src/node.rs
@@ -1077,7 +1077,7 @@ where
             .await;
 
         let blob_store = reth_node_builder::components::create_blob_store(ctx)?;
-        let validator =
+        let mut builder =
             TransactionValidationTaskExecutor::eth_builder(ctx.provider().clone(), evm_config)
                 .no_eip4844()
                 .with_max_tx_input_bytes(ctx.config().txpool.max_tx_input_bytes)
@@ -1089,7 +1089,13 @@ where
                     pool_config_overrides
                         .additional_validation_tasks
                         .unwrap_or_else(|| ctx.config().txpool.additional_validation_tasks),
-                )
+                );
+        // When SGT is configured, skip the inner balance check —
+        // apply_op_checks handles combined (native + SGT) balance validation.
+        if ctx.chain_spec().sgt_activation_timestamp().is_some() {
+            builder = builder.disable_balance_check();
+        }
+        let validator = builder
                 .build_with_tasks(ctx.task_executor().clone(), blob_store.clone())
                 .map(|validator| {
                     OpTransactionValidator::new(validator)

--- a/rust/op-reth/crates/rpc/Cargo.toml
+++ b/rust/op-reth/crates/rpc/Cargo.toml
@@ -44,6 +44,7 @@ reth-optimism-forks.workspace = true
 reth-optimism-trie.workspace = true
 
 # ethereum
+alloy-op-evm.workspace = true
 alloy-eips.workspace = true
 alloy-json-rpc.workspace = true
 alloy-primitives.workspace = true

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -82,11 +82,18 @@ pub struct OpEthApi<N: RpcNodeCore, Rpc: RpcConvert> {
     /// SGT mode flag (per-instance, not shared).
     /// When true, eth_getBalance returns native + SGT combined balance.
     sgt_mode: bool,
+    /// SGT activation timestamp, cached from chain spec at SGT server creation.
+    /// Used to gate balance queries so pre-activation blocks return native-only.
+    sgt_activation_timestamp: Option<u64>,
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> Clone for OpEthApi<N, Rpc> {
     fn clone(&self) -> Self {
-        Self { inner: self.inner.clone(), sgt_mode: self.sgt_mode }
+        Self {
+            inner: self.inner.clone(),
+            sgt_mode: self.sgt_mode,
+            sgt_activation_timestamp: self.sgt_activation_timestamp,
+        }
     }
 }
 
@@ -98,11 +105,17 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> Clone for OpEthApi<N, Rpc> {
 pub trait EthApiWithSgtMode: Clone {
     /// Creates a clone of this API with the specified SGT mode.
     fn clone_with_sgt_mode(&self, sgt_mode: bool) -> Self;
+    /// Sets the SGT activation timestamp for block-gated balance queries.
+    fn set_sgt_activation_timestamp(&mut self, timestamp: Option<u64>);
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> EthApiWithSgtMode for OpEthApi<N, Rpc> {
     fn clone_with_sgt_mode(&self, sgt_mode: bool) -> Self {
         self.with_sgt_mode_changed(sgt_mode)
+    }
+
+    fn set_sgt_activation_timestamp(&mut self, timestamp: Option<u64>) {
+        self.sgt_activation_timestamp = timestamp;
     }
 }
 
@@ -121,12 +134,17 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
             min_suggested_priority_fee,
             flashblocks,
         });
-        Self { inner, sgt_mode }
+        Self { inner, sgt_mode, sgt_activation_timestamp: None }
     }
 
     /// Returns whether SGT mode is enabled.
     pub fn sgt_mode(&self) -> bool {
         self.sgt_mode
+    }
+
+    /// Sets the SGT activation timestamp (cached from chain spec).
+    pub fn set_sgt_activation_timestamp(&mut self, timestamp: Option<u64>) {
+        self.sgt_activation_timestamp = timestamp;
     }
 
     /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
@@ -146,7 +164,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
 
     /// Creates a new `OpEthApi` instance sharing the same underlying components but with different sgt_mode.
     pub fn with_sgt_mode_changed(&self, sgt_mode: bool) -> Self {
-        Self { inner: self.inner.clone(), sgt_mode }
+        Self { inner: self.inner.clone(), sgt_mode, sgt_activation_timestamp: self.sgt_activation_timestamp }
     }
 
     /// Returns a cloned pending block receiver, if any.
@@ -411,6 +429,7 @@ where
         block_id: Option<alloy_rpc_types_eth::BlockId>,
     ) -> impl std::future::Future<Output = Result<U256, Self::Error>> + Send {
         let sgt_mode = self.sgt_mode();
+        let sgt_activation = self.sgt_activation_timestamp;
 
         self.spawn_blocking_io_fut(move |this| async move {
             let state = this.state_at_block_id_or_latest(block_id).await?;
@@ -422,6 +441,24 @@ where
 
             if !sgt_mode {
                 return Ok(native_balance);
+            }
+
+            // Check if SGT is active at the queried block's timestamp.
+            // Skip SGT balance for pre-activation blocks to avoid over-reporting.
+            if let Some(activation) = sgt_activation {
+                use reth_storage_api::{BlockNumReader, HeaderProvider};
+                use alloy_consensus::BlockHeader as _;
+                let block_number = this.provider()
+                    .last_block_number()
+                    .map_err(Self::Error::from_eth_err)?;
+                if let Some(header) = this.provider()
+                    .header_by_number(block_number)
+                    .map_err(Self::Error::from_eth_err)?
+                {
+                    if header.timestamp() < activation {
+                        return Ok(native_balance);
+                    }
+                }
             }
 
             // SGT mode: return native + SGT combined

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -445,12 +445,32 @@ where
 
             // Check if SGT is active at the queried block's timestamp.
             // Skip SGT balance for pre-activation blocks to avoid over-reporting.
-            if let Some(activation) = sgt_activation {
-                use reth_storage_api::{BlockNumReader, HeaderProvider};
+            // If sgt_activation_timestamp is None, SGT is not configured — return native only.
+            let Some(activation) = sgt_activation else {
+                return Ok(native_balance);
+            };
+            {
+                use reth_storage_api::{BlockIdReader, BlockNumReader, HeaderProvider};
                 use alloy_consensus::BlockHeader as _;
+                use alloy_rpc_types_eth::BlockNumberOrTag;
+                // Resolve the queried block's number, defaulting to latest.
+                let num_or_tag = match block_id {
+                    Some(alloy_rpc_types_eth::BlockId::Number(n)) => n,
+                    Some(alloy_rpc_types_eth::BlockId::Hash(h)) => {
+                        match this.provider().block_number(h.block_hash)
+                            .map_err(Self::Error::from_eth_err)?
+                        {
+                            Some(n) => BlockNumberOrTag::Number(n),
+                            None => return Ok(native_balance),
+                        }
+                    }
+                    None => BlockNumberOrTag::Latest,
+                };
                 let block_number = this.provider()
-                    .last_block_number()
-                    .map_err(Self::Error::from_eth_err)?;
+                    .convert_block_number(num_or_tag)
+                    .map_err(Self::Error::from_eth_err)?
+                    .unwrap_or(this.provider().last_block_number()
+                        .map_err(Self::Error::from_eth_err)?);
                 if let Some(header) = this.provider()
                     .header_by_number(block_number)
                     .map_err(Self::Error::from_eth_err)?

--- a/rust/op-reth/crates/rpc/src/eth/mod.rs
+++ b/rust/op-reth/crates/rpc/src/eth/mod.rs
@@ -3,6 +3,7 @@
 pub mod ext;
 pub mod proofs;
 pub mod receipt;
+pub mod sgt;
 pub mod transaction;
 
 mod block;
@@ -34,7 +35,7 @@ use reth_optimism_flashblocks::{
 use reth_primitives_traits::NodePrimitives;
 use reth_rpc::eth::core::EthApiInner;
 use reth_rpc_eth_api::{
-    EthApiTypes, FromEvmError, FullEthApiServer, RpcConvert, RpcConverter, RpcNodeCore,
+    EthApiTypes, FromEthApiError, FromEvmError, FullEthApiServer, RpcConvert, RpcConverter, RpcNodeCore,
     RpcNodeCoreExt, RpcTypes,
     helpers::{
         EthApiSpec, EthFees, EthState, LoadFee, LoadPendingBlock, LoadState, SpawnBlocking, Trace,
@@ -78,11 +79,30 @@ pub type EthApiNodeBackend<N, Rpc> = EthApiInner<N, Rpc>;
 pub struct OpEthApi<N: RpcNodeCore, Rpc: RpcConvert> {
     /// Gateway to node's core components.
     inner: Arc<OpEthApiInner<N, Rpc>>,
+    /// SGT mode flag (per-instance, not shared).
+    /// When true, eth_getBalance returns native + SGT combined balance.
+    sgt_mode: bool,
 }
 
 impl<N: RpcNodeCore, Rpc: RpcConvert> Clone for OpEthApi<N, Rpc> {
     fn clone(&self) -> Self {
-        Self { inner: self.inner.clone() }
+        Self { inner: self.inner.clone(), sgt_mode: self.sgt_mode }
+    }
+}
+
+/// Trait for creating a clone of an EthApi with modified SGT mode.
+///
+/// This trait enables type-safe cloning of EthApi implementations with different
+/// SGT mode configurations, which is necessary for running dual HTTP servers where
+/// one returns native balance only and the other returns native + SGT combined.
+pub trait EthApiWithSgtMode: Clone {
+    /// Creates a clone of this API with the specified SGT mode.
+    fn clone_with_sgt_mode(&self, sgt_mode: bool) -> Self;
+}
+
+impl<N: RpcNodeCore, Rpc: RpcConvert> EthApiWithSgtMode for OpEthApi<N, Rpc> {
+    fn clone_with_sgt_mode(&self, sgt_mode: bool) -> Self {
+        self.with_sgt_mode_changed(sgt_mode)
     }
 }
 
@@ -93,6 +113,7 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
         sequencer_client: Option<SequencerClient>,
         min_suggested_priority_fee: U256,
         flashblocks: Option<FlashblocksListeners<N::Primitives>>,
+        sgt_mode: bool,
     ) -> Self {
         let inner = Arc::new(OpEthApiInner {
             eth_api,
@@ -100,7 +121,12 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
             min_suggested_priority_fee,
             flashblocks,
         });
-        Self { inner }
+        Self { inner, sgt_mode }
+    }
+
+    /// Returns whether SGT mode is enabled.
+    pub fn sgt_mode(&self) -> bool {
+        self.sgt_mode
     }
 
     /// Build a [`OpEthApi`] using [`OpEthApiBuilder`].
@@ -112,9 +138,15 @@ impl<N: RpcNodeCore, Rpc: RpcConvert> OpEthApi<N, Rpc> {
     pub fn eth_api(&self) -> &EthApiNodeBackend<N, Rpc> {
         self.inner.eth_api()
     }
+
     /// Returns the configured sequencer client, if any.
     pub fn sequencer_client(&self) -> Option<&SequencerClient> {
         self.inner.sequencer_client()
+    }
+
+    /// Creates a new `OpEthApi` instance sharing the same underlying components but with different sgt_mode.
+    pub fn with_sgt_mode_changed(&self, sgt_mode: bool) -> Self {
+        Self { inner: self.inner.clone(), sgt_mode }
     }
 
     /// Returns a cloned pending block receiver, if any.
@@ -368,6 +400,37 @@ where
     fn max_proof_window(&self) -> u64 {
         self.inner.eth_api.eth_proof_window()
     }
+
+    /// Returns balance of given account, at given blocknumber.
+    ///
+    /// If SGT mode is enabled, returns native + SGT combined balance.
+    /// Otherwise returns native balance only.
+    fn balance(
+        &self,
+        address: alloy_primitives::Address,
+        block_id: Option<alloy_rpc_types_eth::BlockId>,
+    ) -> impl std::future::Future<Output = Result<U256, Self::Error>> + Send {
+        let sgt_mode = self.sgt_mode();
+
+        self.spawn_blocking_io_fut(move |this| async move {
+            let state = this.state_at_block_id_or_latest(block_id).await?;
+
+            let native_balance = state
+                .account_balance(&address)
+                .map_err(Self::Error::from_eth_err)?
+                .unwrap_or_default();
+
+            if !sgt_mode {
+                return Ok(native_balance);
+            }
+
+            // SGT mode: return native + SGT combined
+            let sgt_balance = sgt::read_sgt_balance(&state, address)
+                .map_err(Self::Error::from_eth_err)?;
+
+            Ok(native_balance.saturating_add(sgt_balance))
+        })
+    }
 }
 
 impl<N, Rpc> EthFees for OpEthApi<N, Rpc>
@@ -456,6 +519,8 @@ pub struct OpEthApiBuilder<NetworkT = Optimism> {
     /// `newPayload` and `forkchoiceUpdated` calls, advancing the canonical chain state.
     /// Requires `flashblocks_url` to be set.
     flashblock_consensus: bool,
+    /// SGT mode flag.
+    sgt_mode: bool,
     /// Marker for network types.
     _nt: PhantomData<NetworkT>,
 }
@@ -468,6 +533,7 @@ impl<NetworkT> Default for OpEthApiBuilder<NetworkT> {
             min_suggested_priority_fee: 1_000_000,
             flashblocks_url: None,
             flashblock_consensus: false,
+            sgt_mode: false,
             _nt: PhantomData,
         }
     }
@@ -482,6 +548,7 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
             min_suggested_priority_fee: 1_000_000,
             flashblocks_url: None,
             flashblock_consensus: false,
+            sgt_mode: false,
             _nt: PhantomData,
         }
     }
@@ -513,6 +580,12 @@ impl<NetworkT> OpEthApiBuilder<NetworkT> {
     /// With flashblock consensus client enabled to drive chain forward
     pub const fn with_flashblock_consensus(mut self, flashblock_consensus: bool) -> Self {
         self.flashblock_consensus = flashblock_consensus;
+        self
+    }
+
+    /// With SGT mode enabled for eth_getBalance
+    pub const fn with_sgt_mode(mut self, sgt_mode: bool) -> Self {
+        self.sgt_mode = sgt_mode;
         self
     }
 }
@@ -550,6 +623,7 @@ where
             min_suggested_priority_fee,
             flashblocks_url,
             flashblock_consensus,
+            sgt_mode,
             ..
         } = self;
         let rpc_converter =
@@ -611,6 +685,7 @@ where
             sequencer_client,
             U256::from(min_suggested_priority_fee),
             flashblocks,
+            sgt_mode,
         ))
     }
 }

--- a/rust/op-reth/crates/rpc/src/eth/sgt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/sgt.rs
@@ -1,0 +1,21 @@
+//! SGT (Soul Gas Token) balance reading utilities for RPC
+
+use alloy_op_evm::sgt::{sgt_balance_slot, SGT_CONTRACT};
+use alloy_primitives::{Address, U256};
+use reth_provider::{ProviderError, StateProvider};
+
+/// Read SGT balance for an account from contract storage.
+///
+/// Returns the SGT balance stored at slot 51 in the SGT predeploy contract.
+pub fn read_sgt_balance<SP>(
+    state: &SP,
+    address: Address,
+) -> Result<U256, ProviderError>
+where
+    SP: StateProvider,
+{
+    let slot = sgt_balance_slot(address);
+    let value = state.storage(SGT_CONTRACT, slot.into())?
+        .unwrap_or_default();
+    Ok(value)
+}

--- a/rust/op-reth/crates/rpc/src/eth/sgt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/sgt.rs
@@ -3,6 +3,7 @@
 use alloy_op_evm::sgt::{sgt_balance_slot, SGT_CONTRACT};
 use alloy_primitives::{Address, U256};
 use reth_provider::{ProviderError, StateProvider};
+use reth_storage_api::StateProviderFactory;
 
 /// Read SGT balance for an account from contract storage.
 ///
@@ -18,4 +19,18 @@ where
     let value = state.storage(SGT_CONTRACT, slot.into())?
         .unwrap_or_default();
     Ok(value)
+}
+
+/// Read SGT balance using a [`StateProviderFactory`] (gets latest state).
+///
+/// Returns 0 on any error.
+pub fn read_sgt_balance_from_provider<F>(client: &F, address: Address) -> U256
+where
+    F: StateProviderFactory,
+{
+    client
+        .latest()
+        .ok()
+        .and_then(|state| read_sgt_balance(&state, address).ok())
+        .unwrap_or_default()
 }

--- a/rust/op-reth/crates/rpc/src/eth/sgt.rs
+++ b/rust/op-reth/crates/rpc/src/eth/sgt.rs
@@ -22,15 +22,10 @@ where
 }
 
 /// Read SGT balance using a [`StateProviderFactory`] (gets latest state).
-///
-/// Returns 0 on any error.
-pub fn read_sgt_balance_from_provider<F>(client: &F, address: Address) -> U256
+pub fn read_sgt_balance_from_provider<F>(client: &F, address: Address) -> Result<U256, ProviderError>
 where
     F: StateProviderFactory,
 {
-    client
-        .latest()
-        .ok()
-        .and_then(|state| read_sgt_balance(&state, address).ok())
-        .unwrap_or_default()
+    let state = client.latest()?;
+    read_sgt_balance(&state, address)
 }

--- a/rust/op-reth/crates/rpc/src/lib.rs
+++ b/rust/op-reth/crates/rpc/src/lib.rs
@@ -23,6 +23,6 @@ pub mod witness;
 pub use engine::OpEngineApiClient;
 pub use engine::{OP_ENGINE_CAPABILITIES, OpEngineApi, OpEngineApiServer};
 pub use error::{OpEthApiError, OpInvalidTransactionError, SequencerClientError};
-pub use eth::{OpEthApi, OpEthApiBuilder, OpReceiptBuilder};
+pub use eth::{EthApiWithSgtMode, OpEthApi, OpEthApiBuilder, OpReceiptBuilder};
 pub use metrics::{EthApiExtMetrics, SequencerMetrics};
 pub use sequencer::SequencerClient;

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -251,8 +251,9 @@ where
             };
             let cost = valid_tx.transaction().cost().saturating_add(cost_addition);
 
-            // Check combined balance (native + SGT) only when SGT is active
-            let effective_balance = if self.chain_spec().is_sgt_active_at_timestamp(self.block_timestamp()) {
+            // Check combined balance (native + SGT) only when SGT will be active at the
+            // next block. Use head.Time + 2 to match op-geth's next-block estimation.
+            let effective_balance = if self.chain_spec().is_sgt_active_at_timestamp(self.block_timestamp() + 2) {
                 balance.saturating_add(self.read_sgt_balance(valid_tx.transaction().sender()))
             } else {
                 balance

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -254,7 +254,15 @@ where
             // Check combined balance (native + SGT) only when SGT will be active at the
             // next block. Use head.Time + 2 to match op-geth's next-block estimation.
             let effective_balance = if self.chain_spec().is_sgt_active_at_timestamp(self.block_timestamp() + 2) {
-                balance.saturating_add(self.read_sgt_balance(valid_tx.transaction().sender()))
+                match self.read_sgt_balance(valid_tx.transaction().sender()) {
+                    Ok(sgt_balance) => balance.saturating_add(sgt_balance),
+                    Err(err) => {
+                        return TransactionValidationOutcome::Error(
+                            *valid_tx.hash(),
+                            err,
+                        );
+                    }
+                }
             } else {
                 balance
             };
@@ -285,25 +293,17 @@ where
     /// Reads the SGT balance for an account.
     ///
     /// Returns the SGT balance from storage, or 0 if unavailable.
-    fn read_sgt_balance(&self, address: alloy_primitives::Address) -> alloy_primitives::U256
+    fn read_sgt_balance(&self, address: alloy_primitives::Address) -> Result<alloy_primitives::U256, Box<dyn core::error::Error + Send + Sync>>
     where
         Client: StateProviderFactory,
     {
-        use alloy_primitives::U256;
         use op_revm::sgt::{sgt_balance_slot, SGT_CONTRACT};
 
         let slot = sgt_balance_slot(address);
-
-        // Read from state
-        let state_provider = match self.inner.client().latest() {
-            Ok(provider) => provider,
-            Err(_) => return U256::ZERO,
-        };
-
-        match state_provider.storage(SGT_CONTRACT, slot.into()) {
-            Ok(Some(value)) => value,
-            _ => U256::ZERO,
-        }
+        let state_provider = self.inner.client().latest()?;
+        let value = state_provider.storage(SGT_CONTRACT, slot.into())?
+            .unwrap_or_default();
+        Ok(value)
     }
 
     /// Wrapper for is valid cross tx

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -288,17 +288,10 @@ where
     where
         Client: StateProviderFactory,
     {
-        use alloy_primitives::{address, keccak256, U256};
+        use alloy_primitives::U256;
+        use op_revm::sgt::{sgt_balance_slot, SGT_CONTRACT};
 
-        // Calculate storage slot for account's SGT balance
-        // Formula: keccak256(abi.encode(account, 51))
-        let mut data = [0u8; 64];
-        data[12..32].copy_from_slice(address.as_slice());
-        data[32..64].copy_from_slice(&U256::from(51u64).to_be_bytes::<32>());
-        let slot = keccak256(data);
-
-        // SGT contract address
-        let sgt_contract = address!("4200000000000000000000000000000000000800");
+        let slot = sgt_balance_slot(address);
 
         // Read from state
         let state_provider = match self.inner.client().latest() {
@@ -306,7 +299,7 @@ where
             Err(_) => return U256::ZERO,
         };
 
-        match state_provider.storage(sgt_contract, slot.into()) {
+        match state_provider.storage(SGT_CONTRACT, slot.into()) {
             Ok(Some(value)) => value,
             _ => U256::ZERO,
         }

--- a/rust/op-reth/crates/txpool/src/validator.rs
+++ b/rust/op-reth/crates/txpool/src/validator.rs
@@ -10,7 +10,7 @@ use reth_primitives_traits::{
     Block, BlockBody, BlockTy, GotExpected, SealedBlock,
     transaction::error::InvalidTransactionError,
 };
-use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, StateProviderFactory};
+use reth_storage_api::{AccountInfoReader, BlockReaderIdExt, StateProvider, StateProviderFactory};
 use reth_transaction_pool::{
     EthPoolTransaction, EthTransactionValidator, TransactionOrigin, TransactionValidationOutcome,
     TransactionValidator, error::InvalidPoolTransactionError,
@@ -251,12 +251,19 @@ where
             };
             let cost = valid_tx.transaction().cost().saturating_add(cost_addition);
 
+            // Check combined balance (native + SGT) only when SGT is active
+            let effective_balance = if self.chain_spec().is_sgt_active_at_timestamp(self.block_timestamp()) {
+                balance.saturating_add(self.read_sgt_balance(valid_tx.transaction().sender()))
+            } else {
+                balance
+            };
+
             // Checks for max cost
-            if cost > balance {
+            if cost > effective_balance {
                 return TransactionValidationOutcome::Invalid(
                     valid_tx.into_transaction(),
                     InvalidTransactionError::InsufficientFunds(
-                        GotExpected { got: balance, expected: cost }.into(),
+                        GotExpected { got: effective_balance, expected: cost }.into(),
                     )
                     .into(),
                 );
@@ -272,6 +279,37 @@ where
             };
         }
         outcome
+    }
+
+    /// Reads the SGT balance for an account.
+    ///
+    /// Returns the SGT balance from storage, or 0 if unavailable.
+    fn read_sgt_balance(&self, address: alloy_primitives::Address) -> alloy_primitives::U256
+    where
+        Client: StateProviderFactory,
+    {
+        use alloy_primitives::{address, keccak256, U256};
+
+        // Calculate storage slot for account's SGT balance
+        // Formula: keccak256(abi.encode(account, 51))
+        let mut data = [0u8; 64];
+        data[12..32].copy_from_slice(address.as_slice());
+        data[32..64].copy_from_slice(&U256::from(51u64).to_be_bytes::<32>());
+        let slot = keccak256(data);
+
+        // SGT contract address
+        let sgt_contract = address!("4200000000000000000000000000000000000800");
+
+        // Read from state
+        let state_provider = match self.inner.client().latest() {
+            Ok(provider) => provider,
+            Err(_) => return U256::ZERO,
+        };
+
+        match state_provider.storage(sgt_contract, slot.into()) {
+            Ok(Some(value)) => value,
+            _ => U256::ZERO,
+        }
     }
 
     /// Wrapper for is valid cross tx

--- a/rust/op-reth/examples/custom-node/src/evm/config.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/config.rs
@@ -84,7 +84,6 @@ impl ConfigureEvm for CustomEvmConfig {
                 parent_hash: block.header().parent_hash(),
                 parent_beacon_block_root: block.header().parent_beacon_block_root(),
                 extra_data: block.header().extra_data().clone(),
-                sgt_config: Default::default(),
             },
             extension: block.extension,
         })
@@ -100,7 +99,6 @@ impl ConfigureEvm for CustomEvmConfig {
                 parent_hash: parent.hash(),
                 parent_beacon_block_root: attributes.inner.parent_beacon_block_root,
                 extra_data: attributes.inner.extra_data,
-                sgt_config: Default::default(),
             },
             extension: attributes.extension,
         })

--- a/rust/op-reth/examples/custom-node/src/evm/config.rs
+++ b/rust/op-reth/examples/custom-node/src/evm/config.rs
@@ -84,6 +84,7 @@ impl ConfigureEvm for CustomEvmConfig {
                 parent_hash: block.header().parent_hash(),
                 parent_beacon_block_root: block.header().parent_beacon_block_root(),
                 extra_data: block.header().extra_data().clone(),
+                sgt_config: Default::default(),
             },
             extension: block.extension,
         })
@@ -99,6 +100,7 @@ impl ConfigureEvm for CustomEvmConfig {
                 parent_hash: parent.hash(),
                 parent_beacon_block_root: attributes.inner.parent_beacon_block_root,
                 extra_data: attributes.inner.extra_data,
+                sgt_config: Default::default(),
             },
             extension: attributes.extension,
         })


### PR DESCRIPTION
The go changes mainly migrates the sgt e2e tests to the op-acceptance tests(`cd op-acceptance-tests && just sgt`).

Essential op-reth changes are under the ./rust directory.

Details of this PR can be seen in the msg of the squashed commit.

External rust dependencies PRs will be created separately.